### PR TITLE
S3-3 Complete v0 API surface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,6 +39,9 @@ name = "awrust-s3-domain"
 version = "0.1.0"
 dependencies = [
  "md-5",
+ "serde",
+ "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -154,6 +163,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -204,6 +241,40 @@ dependencies = [
  "typenum",
  "version_check",
 ]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
@@ -287,6 +358,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,10 +388,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -392,6 +493,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,6 +531,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -437,6 +554,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,6 +577,12 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -561,6 +697,19 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "thread_local"
@@ -729,6 +878,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,6 +900,58 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
 
 [[package]]
 name = "windows-link"
@@ -834,6 +1041,94 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "zmij"

--- a/crates/awrust-s3-domain/Cargo.toml
+++ b/crates/awrust-s3-domain/Cargo.toml
@@ -5,3 +5,8 @@ edition = "2024"
 
 [dependencies]
 md-5 = "0.10"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/awrust-s3-domain/src/fs_store.rs
+++ b/crates/awrust-s3-domain/src/fs_store.rs
@@ -1,0 +1,343 @@
+use crate::{GetObject, ObjectMeta, ObjectSummary, PutObject, Result, Store, StoreError};
+use md5::{Digest, Md5};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub struct FsStore {
+    root: PathBuf,
+}
+
+#[derive(Serialize, Deserialize)]
+struct MetaFile {
+    etag: String,
+    content_type: String,
+    metadata: HashMap<String, String>,
+    last_modified: u64,
+    size: u64,
+}
+
+fn encode_key(key: &str) -> String {
+    key.replace('%', "%25")
+        .replace('/', "%2F")
+        .replace('\\', "%5C")
+        .replace('\0', "%00")
+}
+
+fn decode_key(encoded: &str) -> String {
+    encoded
+        .replace("%2F", "/")
+        .replace("%5C", "\\")
+        .replace("%00", "\0")
+        .replace("%25", "%")
+}
+
+impl FsStore {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        let root = root.into();
+        fs::create_dir_all(&root).expect("create data dir");
+        Self { root }
+    }
+
+    fn bucket_path(&self, name: &str) -> PathBuf {
+        self.root.join(name)
+    }
+
+    fn objects_dir(&self, bucket: &str) -> PathBuf {
+        self.bucket_path(bucket).join("objects")
+    }
+
+    fn meta_dir(&self, bucket: &str) -> PathBuf {
+        self.bucket_path(bucket).join("meta")
+    }
+
+    fn object_path(&self, bucket: &str, key: &str) -> PathBuf {
+        self.objects_dir(bucket).join(encode_key(key))
+    }
+
+    fn meta_path(&self, bucket: &str, key: &str) -> PathBuf {
+        self.meta_dir(bucket)
+            .join(format!("{}.json", encode_key(key)))
+    }
+
+    fn require_bucket(&self, bucket: &str) -> Result<()> {
+        if !self.bucket_path(bucket).is_dir() {
+            return Err(StoreError::BucketNotFound(bucket.to_string()));
+        }
+        Ok(())
+    }
+
+    fn read_meta(&self, bucket: &str, key: &str) -> Result<MetaFile> {
+        let path = self.meta_path(bucket, key);
+        let data = fs::read(&path).map_err(|_| StoreError::ObjectNotFound {
+            bucket: bucket.to_string(),
+            key: key.to_string(),
+        })?;
+        serde_json::from_slice(&data).map_err(|_| StoreError::ObjectNotFound {
+            bucket: bucket.to_string(),
+            key: key.to_string(),
+        })
+    }
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("time after epoch")
+        .as_secs()
+}
+
+impl Store for FsStore {
+    fn create_bucket(&self, name: &str) -> Result<()> {
+        let bp = self.bucket_path(name);
+        fs::create_dir_all(self.objects_dir(name)).ok();
+        fs::create_dir_all(self.meta_dir(name)).ok();
+        let _ = bp;
+        Ok(())
+    }
+
+    fn bucket_exists(&self, name: &str) -> bool {
+        self.bucket_path(name).is_dir()
+    }
+
+    fn delete_bucket(&self, name: &str) -> Result<()> {
+        self.require_bucket(name)?;
+
+        let has_objects = fs::read_dir(self.objects_dir(name))
+            .map(|mut d| d.next().is_some())
+            .unwrap_or(false);
+
+        if has_objects {
+            return Err(StoreError::BucketNotEmpty(name.to_string()));
+        }
+
+        fs::remove_dir_all(self.bucket_path(name)).ok();
+        Ok(())
+    }
+
+    fn list_buckets(&self) -> Vec<String> {
+        let mut names: Vec<String> = fs::read_dir(&self.root)
+            .into_iter()
+            .flatten()
+            .filter_map(|e| {
+                let e = e.ok()?;
+                if e.path().is_dir() {
+                    e.file_name().into_string().ok()
+                } else {
+                    None
+                }
+            })
+            .collect();
+        names.sort();
+        names
+    }
+
+    fn put_object(&self, bucket: &str, key: &str, input: PutObject) -> Result<()> {
+        self.require_bucket(bucket)?;
+
+        let etag = format!("\"{:x}\"", Md5::digest(&input.bytes));
+        let size = input.bytes.len() as u64;
+
+        fs::write(self.object_path(bucket, key), &input.bytes).expect("write object");
+
+        let meta = MetaFile {
+            etag,
+            content_type: input.content_type,
+            metadata: input.metadata,
+            last_modified: now_secs(),
+            size,
+        };
+
+        let meta_json = serde_json::to_vec(&meta).expect("serialize meta");
+        fs::write(self.meta_path(bucket, key), &meta_json).expect("write meta");
+
+        Ok(())
+    }
+
+    fn get_object(&self, bucket: &str, key: &str) -> Result<GetObject> {
+        self.require_bucket(bucket)?;
+
+        let bytes =
+            fs::read(self.object_path(bucket, key)).map_err(|_| StoreError::ObjectNotFound {
+                bucket: bucket.to_string(),
+                key: key.to_string(),
+            })?;
+
+        let mf = self.read_meta(bucket, key)?;
+
+        Ok(GetObject {
+            bytes,
+            meta: ObjectMeta {
+                size: mf.size,
+                etag: mf.etag,
+                content_type: mf.content_type,
+                last_modified: mf.last_modified,
+                metadata: mf.metadata,
+            },
+        })
+    }
+
+    fn head_object(&self, bucket: &str, key: &str) -> Result<ObjectMeta> {
+        self.require_bucket(bucket)?;
+        let mf = self.read_meta(bucket, key)?;
+
+        Ok(ObjectMeta {
+            size: mf.size,
+            etag: mf.etag,
+            content_type: mf.content_type,
+            last_modified: mf.last_modified,
+            metadata: mf.metadata,
+        })
+    }
+
+    fn delete_object(&self, bucket: &str, key: &str) -> Result<()> {
+        self.require_bucket(bucket)?;
+
+        let obj_path = self.object_path(bucket, key);
+        if !obj_path.exists() {
+            return Err(StoreError::ObjectNotFound {
+                bucket: bucket.to_string(),
+                key: key.to_string(),
+            });
+        }
+
+        fs::remove_file(obj_path).ok();
+        fs::remove_file(self.meta_path(bucket, key)).ok();
+        Ok(())
+    }
+
+    fn list_objects(&self, bucket: &str, prefix: Option<&str>) -> Result<Vec<ObjectSummary>> {
+        self.require_bucket(bucket)?;
+
+        let objects_dir = self.objects_dir(bucket);
+        let mut summaries: Vec<ObjectSummary> = fs::read_dir(&objects_dir)
+            .into_iter()
+            .flatten()
+            .filter_map(|e| {
+                let e = e.ok()?;
+                let encoded = e.file_name().into_string().ok()?;
+                let key = decode_key(&encoded);
+
+                if let Some(pfx) = prefix
+                    && !key.starts_with(pfx)
+                {
+                    return None;
+                }
+
+                let mf = self.read_meta(bucket, &key).ok()?;
+                Some(ObjectSummary {
+                    key,
+                    size: mf.size,
+                    etag: mf.etag,
+                    last_modified: mf.last_modified,
+                })
+            })
+            .collect();
+
+        summaries.sort_by(|a, b| a.key.cmp(&b.key));
+        Ok(summaries)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use tempfile::TempDir;
+
+    fn setup() -> (TempDir, FsStore) {
+        let tmp = TempDir::new().unwrap();
+        let store = FsStore::new(tmp.path());
+        (tmp, store)
+    }
+
+    fn put(store: &FsStore, bucket: &str, key: &str, bytes: &[u8]) {
+        store
+            .put_object(
+                bucket,
+                key,
+                PutObject {
+                    bytes: bytes.to_vec(),
+                    content_type: "application/octet-stream".to_string(),
+                    metadata: HashMap::new(),
+                },
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn bucket_lifecycle() {
+        let (_tmp, store) = setup();
+        assert!(!store.bucket_exists("b"));
+        store.create_bucket("b").unwrap();
+        assert!(store.bucket_exists("b"));
+        store.delete_bucket("b").unwrap();
+        assert!(!store.bucket_exists("b"));
+    }
+
+    #[test]
+    fn list_buckets() {
+        let (_tmp, store) = setup();
+        store.create_bucket("bravo").unwrap();
+        store.create_bucket("alpha").unwrap();
+        assert_eq!(store.list_buckets(), vec!["alpha", "bravo"]);
+    }
+
+    #[test]
+    fn object_crud() {
+        let (_tmp, store) = setup();
+        store.create_bucket("b").unwrap();
+        put(&store, "b", "key", b"hello");
+
+        let obj = store.get_object("b", "key").unwrap();
+        assert_eq!(obj.bytes, b"hello");
+        assert_eq!(obj.meta.size, 5);
+
+        store.delete_object("b", "key").unwrap();
+        assert!(store.get_object("b", "key").is_err());
+    }
+
+    #[test]
+    fn head_object() {
+        let (_tmp, store) = setup();
+        store.create_bucket("b").unwrap();
+        store
+            .put_object(
+                "b",
+                "k",
+                PutObject {
+                    bytes: b"data".to_vec(),
+                    content_type: "text/plain".to_string(),
+                    metadata: HashMap::from([("color".to_string(), "red".to_string())]),
+                },
+            )
+            .unwrap();
+
+        let meta = store.head_object("b", "k").unwrap();
+        assert_eq!(meta.content_type, "text/plain");
+        assert_eq!(meta.metadata.get("color").unwrap(), "red");
+    }
+
+    #[test]
+    fn list_with_prefix() {
+        let (_tmp, store) = setup();
+        store.create_bucket("b").unwrap();
+        put(&store, "b", "a/1.txt", b"one");
+        put(&store, "b", "a/2.txt", b"two");
+        put(&store, "b", "b/1.txt", b"three");
+
+        let listed = store.list_objects("b", Some("a/")).unwrap();
+        let keys: Vec<&str> = listed.iter().map(|o| o.key.as_str()).collect();
+        assert_eq!(keys, vec!["a/1.txt", "a/2.txt"]);
+    }
+
+    #[test]
+    fn delete_nonempty_bucket_fails() {
+        let (_tmp, store) = setup();
+        store.create_bucket("b").unwrap();
+        put(&store, "b", "file", b"data");
+        assert!(store.delete_bucket("b").is_err());
+    }
+}

--- a/crates/awrust-s3-domain/src/lib.rs
+++ b/crates/awrust-s3-domain/src/lib.rs
@@ -1,3 +1,7 @@
+mod fs_store;
+
+pub use fs_store::FsStore;
+
 use md5::{Digest, Md5};
 use std::collections::HashMap;
 use std::fmt;
@@ -16,12 +20,8 @@ pub enum StoreError {
 impl fmt::Display for StoreError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            StoreError::BucketNotFound(bucket) => {
-                write!(f, "bucket not found: {bucket}")
-            }
-            StoreError::BucketNotEmpty(bucket) => {
-                write!(f, "bucket not empty: {bucket}")
-            }
+            StoreError::BucketNotFound(bucket) => write!(f, "bucket not found: {bucket}"),
+            StoreError::BucketNotEmpty(bucket) => write!(f, "bucket not empty: {bucket}"),
             StoreError::ObjectNotFound { bucket, key } => {
                 write!(f, "object not found: {bucket}/{key}")
             }
@@ -39,13 +39,35 @@ pub struct ObjectSummary {
     pub last_modified: u64,
 }
 
+#[derive(Debug, Clone)]
+pub struct ObjectMeta {
+    pub size: u64,
+    pub etag: String,
+    pub content_type: String,
+    pub last_modified: u64,
+    pub metadata: HashMap<String, String>,
+}
+
+pub struct PutObject {
+    pub bytes: Vec<u8>,
+    pub content_type: String,
+    pub metadata: HashMap<String, String>,
+}
+
+pub struct GetObject {
+    pub bytes: Vec<u8>,
+    pub meta: ObjectMeta,
+}
+
 pub trait Store: Send + Sync {
     fn create_bucket(&self, name: &str) -> Result<()>;
     fn bucket_exists(&self, name: &str) -> bool;
     fn delete_bucket(&self, name: &str) -> Result<()>;
+    fn list_buckets(&self) -> Vec<String>;
 
-    fn put_object(&self, bucket: &str, key: &str, bytes: Vec<u8>) -> Result<()>;
-    fn get_object(&self, bucket: &str, key: &str) -> Result<Vec<u8>>;
+    fn put_object(&self, bucket: &str, key: &str, input: PutObject) -> Result<()>;
+    fn get_object(&self, bucket: &str, key: &str) -> Result<GetObject>;
+    fn head_object(&self, bucket: &str, key: &str) -> Result<ObjectMeta>;
     fn delete_object(&self, bucket: &str, key: &str) -> Result<()>;
 
     fn list_objects(&self, bucket: &str, prefix: Option<&str>) -> Result<Vec<ObjectSummary>>;
@@ -64,6 +86,9 @@ struct BucketState {
 #[derive(Debug)]
 struct ObjectRecord {
     bytes: Vec<u8>,
+    etag: String,
+    content_type: String,
+    metadata: HashMap<String, String>,
     last_modified: u64,
 }
 
@@ -106,36 +131,80 @@ impl Store for MemoryStore {
         Ok(())
     }
 
-    fn put_object(&self, bucket: &str, key: &str, bytes: Vec<u8>) -> Result<()> {
+    fn list_buckets(&self) -> Vec<String> {
+        let buckets = self.buckets.read().expect("lock poisoned");
+        let mut names: Vec<String> = buckets.keys().cloned().collect();
+        names.sort();
+        names
+    }
+
+    fn put_object(&self, bucket: &str, key: &str, input: PutObject) -> Result<()> {
         let mut buckets = self.buckets.write().expect("lock poisoned");
         let bucket_state = buckets
             .get_mut(bucket)
             .ok_or_else(|| StoreError::BucketNotFound(bucket.to_string()))?;
 
+        let etag = format!("\"{:x}\"", Md5::digest(&input.bytes));
         bucket_state.objects.insert(
             key.to_string(),
             ObjectRecord {
-                bytes,
+                bytes: input.bytes,
+                etag,
+                content_type: input.content_type,
+                metadata: input.metadata,
                 last_modified: now_secs(),
             },
         );
         Ok(())
     }
 
-    fn get_object(&self, bucket: &str, key: &str) -> Result<Vec<u8>> {
+    fn get_object(&self, bucket: &str, key: &str) -> Result<GetObject> {
         let buckets = self.buckets.read().expect("lock poisoned");
         let bucket_state = buckets
             .get(bucket)
             .ok_or_else(|| StoreError::BucketNotFound(bucket.to_string()))?;
 
-        bucket_state
+        let record = bucket_state
             .objects
             .get(key)
-            .map(|r| r.bytes.clone())
             .ok_or_else(|| StoreError::ObjectNotFound {
                 bucket: bucket.to_string(),
                 key: key.to_string(),
-            })
+            })?;
+
+        Ok(GetObject {
+            bytes: record.bytes.clone(),
+            meta: ObjectMeta {
+                size: record.bytes.len() as u64,
+                etag: record.etag.clone(),
+                content_type: record.content_type.clone(),
+                last_modified: record.last_modified,
+                metadata: record.metadata.clone(),
+            },
+        })
+    }
+
+    fn head_object(&self, bucket: &str, key: &str) -> Result<ObjectMeta> {
+        let buckets = self.buckets.read().expect("lock poisoned");
+        let bucket_state = buckets
+            .get(bucket)
+            .ok_or_else(|| StoreError::BucketNotFound(bucket.to_string()))?;
+
+        let record = bucket_state
+            .objects
+            .get(key)
+            .ok_or_else(|| StoreError::ObjectNotFound {
+                bucket: bucket.to_string(),
+                key: key.to_string(),
+            })?;
+
+        Ok(ObjectMeta {
+            size: record.bytes.len() as u64,
+            etag: record.etag.clone(),
+            content_type: record.content_type.clone(),
+            last_modified: record.last_modified,
+            metadata: record.metadata.clone(),
+        })
     }
 
     fn delete_object(&self, bucket: &str, key: &str) -> Result<()> {
@@ -144,8 +213,7 @@ impl Store for MemoryStore {
             .get_mut(bucket)
             .ok_or_else(|| StoreError::BucketNotFound(bucket.to_string()))?;
 
-        let removed = bucket_state.objects.remove(key);
-        if removed.is_none() {
+        if bucket_state.objects.remove(key).is_none() {
             return Err(StoreError::ObjectNotFound {
                 bucket: bucket.to_string(),
                 key: key.to_string(),
@@ -171,7 +239,7 @@ impl Store for MemoryStore {
             .map(|(key, record)| ObjectSummary {
                 key: key.clone(),
                 size: record.bytes.len() as u64,
-                etag: format!("\"{:x}\"", Md5::digest(&record.bytes)),
+                etag: record.etag.clone(),
                 last_modified: record.last_modified,
             })
             .collect();

--- a/crates/awrust-s3-domain/tests/memory_store.rs
+++ b/crates/awrust-s3-domain/tests/memory_store.rs
@@ -1,4 +1,19 @@
-use awrust_s3_domain::{MemoryStore, Store};
+use awrust_s3_domain::{MemoryStore, PutObject, Store};
+use std::collections::HashMap;
+
+fn put(store: &MemoryStore, bucket: &str, key: &str, bytes: &[u8]) {
+    store
+        .put_object(
+            bucket,
+            key,
+            PutObject {
+                bytes: bytes.to_vec(),
+                content_type: "application/octet-stream".to_string(),
+                metadata: HashMap::new(),
+            },
+        )
+        .unwrap();
+}
 
 #[test]
 fn create_bucket() {
@@ -8,24 +23,62 @@ fn create_bucket() {
 }
 
 #[test]
+fn list_buckets() {
+    let store = MemoryStore::new();
+    store.create_bucket("bravo").unwrap();
+    store.create_bucket("alpha").unwrap();
+    assert_eq!(store.list_buckets(), vec!["alpha", "bravo"]);
+}
+
+#[test]
 fn put_get_object() {
     let store = MemoryStore::new();
     store.create_bucket("bucket").unwrap();
+    put(&store, "bucket", "key", b"payload");
+
+    let obj = store.get_object("bucket", "key").unwrap();
+    assert_eq!(obj.bytes, b"payload");
+    assert_eq!(obj.meta.size, 7);
+    assert!(!obj.meta.etag.is_empty());
+}
+
+#[test]
+fn head_object() {
+    let store = MemoryStore::new();
+    store.create_bucket("bucket").unwrap();
+    put(&store, "bucket", "key", b"payload");
+
+    let meta = store.head_object("bucket", "key").unwrap();
+    assert_eq!(meta.size, 7);
+    assert_eq!(meta.content_type, "application/octet-stream");
+}
+
+#[test]
+fn put_with_metadata() {
+    let store = MemoryStore::new();
+    store.create_bucket("bucket").unwrap();
     store
-        .put_object("bucket", "key", b"payload".to_vec())
+        .put_object(
+            "bucket",
+            "key",
+            PutObject {
+                bytes: b"data".to_vec(),
+                content_type: "text/plain".to_string(),
+                metadata: HashMap::from([("color".to_string(), "blue".to_string())]),
+            },
+        )
         .unwrap();
 
-    let bytes = store.get_object("bucket", "key").unwrap();
-    assert_eq!(bytes, b"payload".to_vec());
+    let meta = store.head_object("bucket", "key").unwrap();
+    assert_eq!(meta.content_type, "text/plain");
+    assert_eq!(meta.metadata.get("color").unwrap(), "blue");
 }
 
 #[test]
 fn delete_object() {
     let store = MemoryStore::new();
     store.create_bucket("bucket").unwrap();
-    store
-        .put_object("bucket", "key", b"payload".to_vec())
-        .unwrap();
+    put(&store, "bucket", "key", b"payload");
 
     store.delete_object("bucket", "key").unwrap();
     assert!(store.get_object("bucket", "key").is_err());
@@ -35,15 +88,9 @@ fn delete_object() {
 fn list_with_prefix() {
     let store = MemoryStore::new();
     store.create_bucket("bucket").unwrap();
-    store
-        .put_object("bucket", "a/1.txt", b"one".to_vec())
-        .unwrap();
-    store
-        .put_object("bucket", "a/2.txt", b"two".to_vec())
-        .unwrap();
-    store
-        .put_object("bucket", "b/1.txt", b"three".to_vec())
-        .unwrap();
+    put(&store, "bucket", "a/1.txt", b"one");
+    put(&store, "bucket", "a/2.txt", b"two");
+    put(&store, "bucket", "b/1.txt", b"three");
 
     let listed = store.list_objects("bucket", Some("a/")).unwrap();
     let keys: Vec<&str> = listed.iter().map(|o| o.key.as_str()).collect();

--- a/crates/awrust-s3-server/src/handlers.rs
+++ b/crates/awrust-s3-server/src/handlers.rs
@@ -1,15 +1,15 @@
-use awrust_s3_domain::Store;
+use awrust_s3_domain::{ObjectMeta, PutObject, Store};
 use axum::body::Bytes;
 use axum::extract::{Path, Query, State};
-use axum::http::{HeaderMap, StatusCode};
+use axum::http::{HeaderMap, HeaderName, StatusCode};
 use axum::response::{IntoResponse, Response};
-use md5::{Digest, Md5};
 use serde::Deserialize;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, UNIX_EPOCH};
 
 use crate::error::S3Error;
-use crate::xml::{ListBucketResult, ObjectEntry, XmlResponse};
+use crate::xml::{BucketEntry, ListAllMyBucketsResult, ListBucketResult, ObjectEntry, XmlResponse};
 
 type S3Result<T> = Result<T, S3Error>;
 
@@ -38,6 +38,14 @@ pub async fn delete_bucket(
 ) -> S3Result<StatusCode> {
     store.delete_bucket(&bucket)?;
     Ok(StatusCode::NO_CONTENT)
+}
+
+pub async fn list_buckets(State(store): State<Arc<dyn Store>>) -> Response {
+    let names = store.list_buckets();
+    let result = ListAllMyBucketsResult {
+        buckets: names.into_iter().map(|name| BucketEntry { name }).collect(),
+    };
+    XmlResponse(result).into_response()
 }
 
 #[derive(Deserialize, Default)]
@@ -82,40 +90,44 @@ pub async fn list_objects(
 pub async fn put_object(
     State(store): State<Arc<dyn Store>>,
     Path((bucket, key)): Path<(String, String)>,
+    headers: HeaderMap,
     body: Bytes,
 ) -> S3Result<Response> {
-    let etag = format!("\"{:x}\"", Md5::digest(&body));
-    store.put_object(&bucket, &key, body.to_vec())?;
-    Ok((StatusCode::OK, [("etag", etag)]).into_response())
+    let content_type = headers
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/octet-stream")
+        .to_string();
+
+    let metadata = extract_amz_meta(&headers);
+
+    let input = PutObject {
+        bytes: body.to_vec(),
+        content_type,
+        metadata,
+    };
+
+    store.put_object(&bucket, &key, input)?;
+
+    let meta = store.head_object(&bucket, &key)?;
+    Ok((StatusCode::OK, [("etag", meta.etag)]).into_response())
 }
 
 pub async fn get_object(
     State(store): State<Arc<dyn Store>>,
     Path((bucket, key)): Path<(String, String)>,
 ) -> S3Result<Response> {
-    let bytes = store.get_object(&bucket, &key)?;
-    let etag = format!("\"{:x}\"", Md5::digest(&bytes));
-    let len = bytes.len().to_string();
-
-    let mut headers = HeaderMap::new();
-    headers.insert("etag", etag.parse().expect("valid header"));
-    headers.insert("content-length", len.parse().expect("valid header"));
-
-    Ok((StatusCode::OK, headers, bytes).into_response())
+    let obj = store.get_object(&bucket, &key)?;
+    let headers = meta_to_headers(&obj.meta);
+    Ok((StatusCode::OK, headers, obj.bytes).into_response())
 }
 
 pub async fn head_object(
     State(store): State<Arc<dyn Store>>,
     Path((bucket, key)): Path<(String, String)>,
 ) -> S3Result<Response> {
-    let bytes = store.get_object(&bucket, &key)?;
-    let etag = format!("\"{:x}\"", Md5::digest(&bytes));
-    let len = bytes.len().to_string();
-
-    let mut headers = HeaderMap::new();
-    headers.insert("etag", etag.parse().expect("valid header"));
-    headers.insert("content-length", len.parse().expect("valid header"));
-
+    let meta = store.head_object(&bucket, &key)?;
+    let headers = meta_to_headers(&meta);
     Ok((StatusCode::OK, headers).into_response())
 }
 
@@ -125,6 +137,51 @@ pub async fn delete_object(
 ) -> S3Result<StatusCode> {
     store.delete_object(&bucket, &key)?;
     Ok(StatusCode::NO_CONTENT)
+}
+
+fn extract_amz_meta(headers: &HeaderMap) -> HashMap<String, String> {
+    headers
+        .iter()
+        .filter_map(|(name, value)| {
+            let name_str = name.as_str();
+            if let Some(key) = name_str.strip_prefix("x-amz-meta-") {
+                value
+                    .to_str()
+                    .ok()
+                    .map(|v| (key.to_string(), v.to_string()))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn meta_to_headers(meta: &ObjectMeta) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert("etag", meta.etag.parse().expect("valid header"));
+    headers.insert(
+        "content-length",
+        meta.size.to_string().parse().expect("valid header"),
+    );
+    headers.insert(
+        "content-type",
+        meta.content_type.parse().expect("valid header"),
+    );
+    headers.insert(
+        "last-modified",
+        format_iso8601(meta.last_modified)
+            .parse()
+            .expect("valid header"),
+    );
+
+    for (key, value) in &meta.metadata {
+        let header_name = format!("x-amz-meta-{key}");
+        if let (Ok(name), Ok(val)) = (header_name.parse::<HeaderName>(), value.parse()) {
+            headers.insert(name, val);
+        }
+    }
+
+    headers
 }
 
 fn format_iso8601(epoch_secs: u64) -> String {

--- a/crates/awrust-s3-server/src/main.rs
+++ b/crates/awrust-s3-server/src/main.rs
@@ -2,7 +2,7 @@ mod error;
 mod handlers;
 mod xml;
 
-use awrust_s3_domain::{MemoryStore, Store};
+use awrust_s3_domain::{FsStore, MemoryStore, Store};
 use axum::routing::{get, put};
 use axum::{Json, Router};
 use serde::Serialize;
@@ -21,9 +21,22 @@ struct HealthResponse {
 async fn main() {
     init_tracing();
 
-    let store: Arc<dyn Store> = Arc::new(MemoryStore::new());
+    let store_type = std::env::var("AWRUST_S3_STORE").unwrap_or_else(|_| "memory".to_string());
+    let store: Arc<dyn Store> = match store_type.as_str() {
+        "fs" => {
+            let data_dir =
+                std::env::var("AWRUST_S3_DATA_DIR").unwrap_or_else(|_| "/data".to_string());
+            info!(backend = "fs", %data_dir, "using filesystem store");
+            Arc::new(FsStore::new(data_dir))
+        }
+        _ => {
+            info!(backend = "memory", "using in-memory store");
+            Arc::new(MemoryStore::new())
+        }
+    };
 
     let app = Router::new()
+        .route("/", get(handlers::list_buckets))
         .route("/health", get(health))
         .route(
             "/:bucket",

--- a/crates/awrust-s3-server/src/xml.rs
+++ b/crates/awrust-s3-server/src/xml.rs
@@ -32,6 +32,20 @@ pub struct ObjectEntry {
     pub etag: String,
 }
 
+#[derive(Serialize)]
+#[serde(rename = "ListAllMyBucketsResult")]
+pub struct ListAllMyBucketsResult {
+    #[serde(rename = "Buckets")]
+    pub buckets: Vec<BucketEntry>,
+}
+
+#[derive(Serialize)]
+#[serde(rename = "Bucket")]
+pub struct BucketEntry {
+    #[serde(rename = "Name")]
+    pub name: String,
+}
+
 pub struct XmlResponse<T: Serialize>(pub T);
 
 impl<T: Serialize> IntoResponse for XmlResponse<T> {

--- a/tests/integration/features/bucket.feature
+++ b/tests/integration/features/bucket.feature
@@ -19,3 +19,10 @@ Feature: Bucket operations
     Given bucket "idem-bucket" exists
     When I create bucket "idem-bucket"
     Then bucket "idem-bucket" should exist
+
+  Scenario: List all buckets
+    Given bucket "alpha-bucket" exists
+    And bucket "beta-bucket" exists
+    When I list all buckets
+    Then the bucket list should contain "alpha-bucket"
+    And the bucket list should contain "beta-bucket"

--- a/tests/integration/features/object.feature
+++ b/tests/integration/features/object.feature
@@ -22,3 +22,18 @@ Feature: Object operations
   Scenario: Get non-existent object fails
     When I try to get object "obj-bucket/nope.txt"
     Then the operation should fail
+
+  Scenario: HEAD object returns metadata
+    When I put object "obj-bucket/head-test.txt" with content "headme"
+    When I head object "obj-bucket/head-test.txt"
+    Then the head response content length should be "6"
+    And the head response should have an etag
+
+  Scenario: Put and get with content type
+    When I upload "obj-bucket/typed.json" with body "{}" and content type "application/json"
+    Then object "obj-bucket/typed.json" should have content type "application/json"
+
+  Scenario: Put and get with custom metadata
+    When I upload "obj-bucket/meta.txt" with body "data" and metadata "color=blue,env=test"
+    Then object "obj-bucket/meta.txt" should have metadata "color" with value "blue"
+    And object "obj-bucket/meta.txt" should have metadata "env" with value "test"

--- a/tests/integration/steps/bucket_steps.py
+++ b/tests/integration/steps/bucket_steps.py
@@ -38,3 +38,16 @@ def step_assert_bucket_not_exists(context, name):
         assert False, f"bucket {name} still exists"
     except ClientError as e:
         assert e.response["Error"]["Code"] in ("404", "NoSuchBucket")
+
+
+@when("I list all buckets")
+def step_list_all_buckets(context):
+    resp = context.s3.list_buckets()
+    context.bucket_list = [b["Name"] for b in resp.get("Buckets", [])]
+
+
+@then('the bucket list should contain "{name}"')
+def step_assert_bucket_in_list(context, name):
+    assert name in context.bucket_list, (
+        f"expected {name} in {context.bucket_list}"
+    )

--- a/tests/integration/steps/object_steps.py
+++ b/tests/integration/steps/object_steps.py
@@ -70,3 +70,55 @@ def step_assert_listed_keys(context, expected):
 @then("the operation should fail")
 def step_assert_operation_failed(context):
     assert context.last_error is not None, "expected an error but operation succeeded"
+
+
+@when('I head object "{path}"')
+def step_head_object(context, path):
+    bucket, key = _split(path)
+    context.head_response = context.s3.head_object(Bucket=bucket, Key=key)
+
+
+@then('the head response content length should be "{length}"')
+def step_assert_head_content_length(context, length):
+    actual = str(context.head_response["ContentLength"])
+    assert actual == length, f"expected content-length {length}, got {actual}"
+
+
+@then("the head response should have an etag")
+def step_assert_head_etag(context):
+    etag = context.head_response.get("ETag")
+    assert etag is not None and len(etag) > 0, "expected ETag header"
+
+
+@when('I upload "{path}" with body "{content}" and content type "{ct}"')
+def step_upload_with_ct(context, path, content, ct):
+    bucket, key = _split(path)
+    context.s3.put_object(Bucket=bucket, Key=key, Body=content.encode(), ContentType=ct)
+
+
+@then('object "{path}" should have content type "{expected_ct}"')
+def step_assert_content_type(context, path, expected_ct):
+    bucket, key = _split(path)
+    resp = context.s3.head_object(Bucket=bucket, Key=key)
+    actual = resp["ContentType"]
+    assert actual == expected_ct, f"expected content-type {expected_ct}, got {actual}"
+
+
+@when('I upload "{path}" with body "{content}" and metadata "{meta_str}"')
+def step_upload_with_metadata(context, path, content, meta_str):
+    bucket, key = _split(path)
+    metadata = dict(pair.split("=") for pair in meta_str.split(","))
+    context.s3.put_object(
+        Bucket=bucket, Key=key, Body=content.encode(), Metadata=metadata
+    )
+
+
+@then('object "{path}" should have metadata "{meta_key}" with value "{meta_value}"')
+def step_assert_metadata(context, path, meta_key, meta_value):
+    bucket, key = _split(path)
+    resp = context.s3.head_object(Bucket=bucket, Key=key)
+    metadata = resp.get("Metadata", {})
+    actual = metadata.get(meta_key)
+    assert actual == meta_value, (
+        f"expected metadata {meta_key}={meta_value}, got {actual} (all: {metadata})"
+    )


### PR DESCRIPTION
Enrich the Store trait with object metadata (Content-Type,
x-amz-meta-*, ETag, Last-Modified) carried through PutObject,
GetObject, and ObjectMeta types. Add dedicated head_object to
avoid cloning bytes. Add list_buckets for GET / endpoint.

Implement FsStore backed by the filesystem with URL-encoded
keys and JSON metadata sidecar files, selectable via
AWRUST_S3_STORE=fs and AWRUST_S3_DATA_DIR env vars.

Add ListAllMyBucketsResult XML response. All handlers now
return Content-Type, x-amz-meta-* headers, and Last-Modified.

BDD scenarios cover list buckets, HEAD object, content type
round-trip, and custom metadata round-trip. FsStore has its
own unit test suite using tmpdir.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
