### PR TITLE
S3-3 Update docs for v0 complete, add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - run: cargo fmt --check
+      - run: cargo clippy -- -D warnings
+      - run: cargo test --workspace
+
+  release:
+    name: Build & Push Docker Image
+    runs-on: ubuntu-latest
+    needs: test
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # awrust-s3 — Architecture (v0)
 
-**Status:** Draft (v0)
+**Status:** v0 complete
 **Project:** awrust-s3
 **License:** MIT
 **Primary distribution:** Docker image (Linux amd64/arm64)
@@ -303,7 +303,8 @@ Scenarios cover:
 GitHub Actions (`.github/workflows/ci.yml`):
 
 * **build** job: `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test`, release build
-* **integration** job: Python 3.11, `behave` + `boto3` against the server
+* **integration** job: `behave` + `boto3` against both memory and fs backends
+* **docker** job: build Docker image, run BDD suite against it (memory + fs)
 
 ---
 
@@ -313,16 +314,20 @@ GitHub Actions (`.github/workflows/ci.yml`):
 awrust-s3/
   README.md
   ARCHITECTURE.md
-  COMPAT.md
   LICENSE
   Cargo.toml
   crates/
-    awrust-s3-core/
-    awrust-s3-server/
+    awrust-s3-domain/    # Store trait, MemoryStore, FsStore
+    awrust-s3-server/    # Axum HTTP server, handlers, XML
   docker/
     Dockerfile
   tests/
     integration/
+      features/          # Gherkin BDD scenarios
+      steps/             # Python step implementations (boto3)
+      environment.py     # Server lifecycle (cargo or Docker)
+  docs/
+    adr/                 # Architecture Decision Records
 ```
 
 ---
@@ -340,12 +345,12 @@ awrust-s3/
 
 ---
 
-## 13. Open questions
+## 13. Resolved questions
 
-* Include ListAllMyBuckets in v0?
-* Idempotent bucket creation vs strict AWS error?
-* Filesystem store in v0 or v0.2?
-* Basic range requests in early versions?
+* Include ListAllMyBuckets in v0? **Yes** — `GET /` returns `ListAllMyBucketsResult`.
+* Idempotent bucket creation vs strict AWS error? **Idempotent** — `create_bucket` is a no-op if bucket exists.
+* Filesystem store in v0 or v0.2? **v0** — `FsStore` implemented, selectable via `AWRUST_S3_STORE=fs`.
+* Basic range requests in early versions? **Deferred** to v0.x.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,26 +2,36 @@
 
 Minimal, deterministic S3-compatible emulator written in Rust. Designed for local development, integration tests, and CI pipelines.
 
-Status: v0 in progress.
+Status: **v0 complete.**
 
-## Running
+## Quick start
+
+```bash
+docker run --rm -p 4566:4566 ghcr.io/awrust/awrust-s3:0.x
+```
+
+Or from source:
 
 ```bash
 cargo run -p awrust-s3-server
 ```
 
-The server listens on `0.0.0.0:4566` by default. Override with `AWRUST_S3_LISTEN_ADDR`:
+## Configuration
 
-```bash
-AWRUST_S3_LISTEN_ADDR=127.0.0.1:9000 cargo run -p awrust-s3-server
-```
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AWRUST_S3_LISTEN_ADDR` | `0.0.0.0:4566` | Listen address |
+| `AWRUST_S3_STORE` | `memory` | Storage backend (`memory` or `fs`) |
+| `AWRUST_S3_DATA_DIR` | `/data` | Data directory when `store=fs` |
+| `AWRUST_LOG` | `info` | Log level |
 
-### Usage with AWS CLI
+## Usage with AWS CLI
 
 ```bash
 aws --endpoint-url=http://localhost:4566 --no-sign-request s3 mb s3://my-bucket
 aws --endpoint-url=http://localhost:4566 --no-sign-request s3 cp file.txt s3://my-bucket/file.txt
 aws --endpoint-url=http://localhost:4566 --no-sign-request s3 ls s3://my-bucket/
+aws --endpoint-url=http://localhost:4566 --no-sign-request s3 ls
 aws --endpoint-url=http://localhost:4566 --no-sign-request s3 rm s3://my-bucket/file.txt
 aws --endpoint-url=http://localhost:4566 --no-sign-request s3 rb s3://my-bucket
 ```
@@ -46,10 +56,11 @@ cargo clippy -- -D warnings
 ```bash
 pip install -r tests/integration/requirements.txt
 cd tests/integration
-behave
+behave                          # memory backend via cargo run
+STORE=fs behave                 # filesystem backend via cargo run
+IMAGE=awrust-s3:test behave     # memory backend via Docker
+IMAGE=awrust-s3:test STORE=fs behave  # filesystem backend via Docker
 ```
-
-The integration suite automatically builds and starts the server on a random port, runs all scenarios, and tears down cleanly.
 
 ## Architecture Decisions
 


### PR DESCRIPTION
Mark v0 as complete in README and ARCHITECTURE.md. Update
README with Docker quick start, configuration table, and all
four BDD test modes. Fix repo structure to match actual crate
names. Resolve all open questions in §13.

Add release.yml workflow triggered on semver tags — runs tests,
builds multi-arch Docker image (amd64 + arm64) via buildx, and
pushes to GHCR with semver tags.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
