### PR TITLE
S3-12 Add batch delete (POST /<bucket>?delete)

### DIFF
--- a/crates/awrust-s3-server/src/handlers.rs
+++ b/crates/awrust-s3-server/src/handlers.rs
@@ -10,8 +10,9 @@ use std::time::{Duration, UNIX_EPOCH};
 
 use crate::error::S3Error;
 use crate::xml::{
-    BucketEntry, BucketList, CompleteMultipartUploadResult, InitiateMultipartUploadResult,
-    ListAllMyBucketsResult, ListBucketResult, ObjectEntry, XmlResponse,
+    BucketEntry, BucketList, CompleteMultipartUploadResult, DeleteErrorEntry, DeleteResult,
+    DeletedEntry, InitiateMultipartUploadResult, ListAllMyBucketsResult, ListBucketResult,
+    ObjectEntry, XmlResponse,
 };
 
 type S3Result<T> = Result<T, S3Error>;
@@ -41,6 +42,54 @@ pub async fn delete_bucket(
 ) -> S3Result<StatusCode> {
     store.delete_bucket(&bucket)?;
     Ok(StatusCode::NO_CONTENT)
+}
+
+#[derive(Deserialize, Default)]
+pub struct BucketQueryParams {
+    pub delete: Option<String>,
+}
+
+pub async fn post_bucket(
+    State(store): State<Arc<dyn Store>>,
+    Path(bucket): Path<String>,
+    Query(params): Query<BucketQueryParams>,
+    body: Bytes,
+) -> S3Result<Response> {
+    if params.delete.is_none() {
+        return Ok(StatusCode::BAD_REQUEST.into_response());
+    }
+
+    if !store.bucket_exists(&bucket) {
+        return Err(awrust_s3_domain::StoreError::BucketNotFound(bucket).into());
+    }
+
+    let request: crate::xml::DeleteRequest =
+        quick_xml::de::from_str(&String::from_utf8_lossy(&body))
+            .map_err(|_| awrust_s3_domain::StoreError::BucketNotFound(bucket.clone()))?;
+
+    let mut deleted = Vec::new();
+    let mut errors = Vec::new();
+
+    for obj in &request.objects {
+        match store.delete_object(&bucket, &obj.key) {
+            Ok(()) | Err(awrust_s3_domain::StoreError::ObjectNotFound { .. }) => {
+                if !request.quiet {
+                    deleted.push(DeletedEntry {
+                        key: obj.key.clone(),
+                    });
+                }
+            }
+            Err(e) => {
+                errors.push(DeleteErrorEntry {
+                    key: obj.key.clone(),
+                    code: "InternalError".to_string(),
+                    message: e.to_string(),
+                });
+            }
+        }
+    }
+
+    Ok(XmlResponse(DeleteResult { deleted, errors }).into_response())
 }
 
 pub async fn list_buckets(State(store): State<Arc<dyn Store>>) -> Response {

--- a/crates/awrust-s3-server/src/main.rs
+++ b/crates/awrust-s3-server/src/main.rs
@@ -47,7 +47,8 @@ async fn main() {
             put(handlers::create_bucket)
                 .head(handlers::head_bucket)
                 .delete(handlers::delete_bucket)
-                .get(handlers::list_objects),
+                .get(handlers::list_objects)
+                .post(handlers::post_bucket),
         )
         .route(
             "/:bucket/*key",

--- a/crates/awrust-s3-server/src/xml.rs
+++ b/crates/awrust-s3-server/src/xml.rs
@@ -97,6 +97,46 @@ pub struct CompletedPart {
     pub etag: String,
 }
 
+#[derive(Deserialize)]
+#[serde(rename = "Delete")]
+pub struct DeleteRequest {
+    #[serde(rename = "Quiet", default)]
+    pub quiet: bool,
+    #[serde(rename = "Object")]
+    pub objects: Vec<DeleteRequestObject>,
+}
+
+#[derive(Deserialize)]
+pub struct DeleteRequestObject {
+    #[serde(rename = "Key")]
+    pub key: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename = "DeleteResult")]
+pub struct DeleteResult {
+    #[serde(rename = "Deleted", default, skip_serializing_if = "Vec::is_empty")]
+    pub deleted: Vec<DeletedEntry>,
+    #[serde(rename = "Error", default, skip_serializing_if = "Vec::is_empty")]
+    pub errors: Vec<DeleteErrorEntry>,
+}
+
+#[derive(Serialize)]
+pub struct DeletedEntry {
+    #[serde(rename = "Key")]
+    pub key: String,
+}
+
+#[derive(Serialize)]
+pub struct DeleteErrorEntry {
+    #[serde(rename = "Key")]
+    pub key: String,
+    #[serde(rename = "Code")]
+    pub code: String,
+    #[serde(rename = "Message")]
+    pub message: String,
+}
+
 pub struct XmlResponse<T: Serialize>(pub T);
 
 impl<T: Serialize> IntoResponse for XmlResponse<T> {

--- a/tests/integration/features/batch_delete.feature
+++ b/tests/integration/features/batch_delete.feature
@@ -1,0 +1,34 @@
+Feature: Batch delete objects
+
+  Background:
+    Given bucket "batch-bucket" exists
+
+  Scenario: Delete multiple existing objects
+    Given object "batch-bucket/a.txt" contains "alpha"
+    And object "batch-bucket/b.txt" contains "bravo"
+    And object "batch-bucket/c.txt" contains "charlie"
+    When I batch delete keys "a.txt,b.txt,c.txt" from "batch-bucket"
+    Then the batch delete response should have 3 deleted keys
+    And the batch delete response should have 0 errors
+    And object "batch-bucket/a.txt" should not exist
+    And object "batch-bucket/b.txt" should not exist
+    And object "batch-bucket/c.txt" should not exist
+
+  Scenario: Delete mix of existing and non-existing keys
+    Given object "batch-bucket/real.txt" contains "data"
+    When I batch delete keys "real.txt,ghost.txt" from "batch-bucket"
+    Then the batch delete response should have 2 deleted keys
+    And the batch delete response should have 0 errors
+    And object "batch-bucket/real.txt" should not exist
+
+  Scenario: Delete non-existing keys from empty bucket
+    When I batch delete keys "nope1.txt,nope2.txt" from "batch-bucket"
+    Then the batch delete response should have 2 deleted keys
+    And the batch delete response should have 0 errors
+
+  Scenario: Quiet mode suppresses deleted entries
+    Given object "batch-bucket/q.txt" contains "quiet"
+    When I batch delete keys "q.txt" from "batch-bucket" in quiet mode
+    Then the batch delete response should have 0 deleted keys
+    And the batch delete response should have 0 errors
+    And object "batch-bucket/q.txt" should not exist

--- a/tests/integration/steps/batch_delete_steps.py
+++ b/tests/integration/steps/batch_delete_steps.py
@@ -1,0 +1,29 @@
+from behave import when, then
+
+
+@when('I batch delete keys "{keys}" from "{bucket}"')
+def step_batch_delete(context, keys, bucket):
+    objects = [{"Key": k} for k in keys.split(",")]
+    context.batch_delete_response = context.s3.delete_objects(
+        Bucket=bucket, Delete={"Objects": objects}
+    )
+
+
+@when('I batch delete keys "{keys}" from "{bucket}" in quiet mode')
+def step_batch_delete_quiet(context, keys, bucket):
+    objects = [{"Key": k} for k in keys.split(",")]
+    context.batch_delete_response = context.s3.delete_objects(
+        Bucket=bucket, Delete={"Objects": objects, "Quiet": True}
+    )
+
+
+@then("the batch delete response should have {count:d} deleted keys")
+def step_assert_deleted_count(context, count):
+    deleted = context.batch_delete_response.get("Deleted", [])
+    assert len(deleted) == count, f"expected {count} deleted, got {len(deleted)}: {deleted}"
+
+
+@then("the batch delete response should have {count:d} errors")
+def step_assert_error_count(context, count):
+    errors = context.batch_delete_response.get("Errors", [])
+    assert len(errors) == count, f"expected {count} errors, got {len(errors)}: {errors}"


### PR DESCRIPTION
Adds `POST /<bucket>?delete` endpoint for SDK bulk delete operations and `aws s3 rm --recursive`.

## Implementation & Notes
* Handler parses `<Delete>` XML body, iterates over keys calling the existing `delete_object` store method
* Non-existing keys are treated as successful deletes, matching real S3 behavior — no new `Store` trait method needed
* Supports `<Quiet>true</Quiet>` flag to suppress `<Deleted>` entries in the response
* XML types added: `DeleteRequest`, `DeleteResult`, `DeletedEntry`, `DeleteErrorEntry`

## How to Test
```bash
cargo fmt --all --check
cargo clippy -- -D warnings
cargo test --workspace
cd tests/integration && behave features/batch_delete.feature
```

4 BDD scenarios cover:
- Delete multiple existing objects
- Mix of existing and non-existing keys (all succeed)
- Delete from empty bucket (all succeed)
- Quiet mode suppresses deleted entries

## Suggested Commit Message
```
S3-12 Add batch delete (POST /<bucket>?delete) (#12)

Required for `aws s3 rm --recursive` and SDK bulk cleanup.
Parses Delete XML body, loops over keys calling delete_object,
treats non-existing keys as successful deletes (matching real
S3 behavior), and supports the Quiet flag to suppress deleted
entries in the response.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)