### PR TITLE
S3-13 Add copy object support via x-amz-copy-source header

### DIFF
--- a/crates/awrust-s3-domain/src/fs_store.rs
+++ b/crates/awrust-s3-domain/src/fs_store.rs
@@ -528,6 +528,42 @@ mod tests {
     }
 
     #[test]
+    fn copy_via_get_put() {
+        let (_tmp, store) = setup();
+        store.create_bucket("src").unwrap();
+        store.create_bucket("dst").unwrap();
+        store
+            .put_object(
+                "src",
+                "file.txt",
+                PutObject {
+                    bytes: b"payload".to_vec(),
+                    content_type: "text/plain".to_string(),
+                    metadata: HashMap::from([("tag".to_string(), "v1".to_string())]),
+                },
+            )
+            .unwrap();
+
+        let obj = store.get_object("src", "file.txt").unwrap();
+        store
+            .put_object(
+                "dst",
+                "copy.txt",
+                PutObject {
+                    bytes: obj.bytes,
+                    content_type: obj.meta.content_type,
+                    metadata: obj.meta.metadata,
+                },
+            )
+            .unwrap();
+
+        let copied = store.get_object("dst", "copy.txt").unwrap();
+        assert_eq!(copied.bytes, b"payload");
+        assert_eq!(copied.meta.content_type, "text/plain");
+        assert_eq!(copied.meta.metadata.get("tag").unwrap(), "v1");
+    }
+
+    #[test]
     fn pagination() {
         let (_tmp, store) = setup();
         store.create_bucket("b").unwrap();

--- a/crates/awrust-s3-server/src/handlers.rs
+++ b/crates/awrust-s3-server/src/handlers.rs
@@ -10,9 +10,9 @@ use std::time::{Duration, UNIX_EPOCH};
 
 use crate::error::S3Error;
 use crate::xml::{
-    BucketEntry, BucketList, CompleteMultipartUploadResult, DeleteErrorEntry, DeleteResult,
-    DeletedEntry, InitiateMultipartUploadResult, ListAllMyBucketsResult, ListBucketResult,
-    ObjectEntry, XmlResponse,
+    BucketEntry, BucketList, CompleteMultipartUploadResult, CopyObjectResult, DeleteErrorEntry,
+    DeleteResult, DeletedEntry, InitiateMultipartUploadResult, ListAllMyBucketsResult,
+    ListBucketResult, ObjectEntry, XmlResponse,
 };
 
 type S3Result<T> = Result<T, S3Error>;
@@ -171,6 +171,13 @@ pub async fn put_object_or_part(
     headers: HeaderMap,
     body: Bytes,
 ) -> S3Result<Response> {
+    if let Some(copy_source) = headers
+        .get("x-amz-copy-source")
+        .and_then(|v| v.to_str().ok())
+    {
+        return copy_object(&store, &bucket, &key, copy_source);
+    }
+
     if let (Some(upload_id), Some(part_number)) = (&params.upload_id, params.part_number) {
         let etag = store.upload_part(&bucket, &key, upload_id, part_number, body.to_vec())?;
         return Ok((StatusCode::OK, [("etag", etag)]).into_response());
@@ -305,6 +312,40 @@ pub async fn delete_object_or_abort(
     }
     store.delete_object(&bucket, &key)?;
     Ok(StatusCode::NO_CONTENT)
+}
+
+fn copy_object(
+    store: &Arc<dyn Store>,
+    dst_bucket: &str,
+    dst_key: &str,
+    copy_source: &str,
+) -> S3Result<Response> {
+    let source = copy_source.strip_prefix('/').unwrap_or(copy_source);
+    let (src_bucket, src_key) =
+        source
+            .split_once('/')
+            .ok_or_else(|| awrust_s3_domain::StoreError::ObjectNotFound {
+                bucket: source.to_string(),
+                key: String::new(),
+            })?;
+
+    let obj = store.get_object(src_bucket, src_key)?;
+    store.put_object(
+        dst_bucket,
+        dst_key,
+        PutObject {
+            bytes: obj.bytes,
+            content_type: obj.meta.content_type,
+            metadata: obj.meta.metadata,
+        },
+    )?;
+
+    let meta = store.head_object(dst_bucket, dst_key)?;
+    Ok(XmlResponse(CopyObjectResult {
+        etag: meta.etag,
+        last_modified: format_iso8601(meta.last_modified),
+    })
+    .into_response())
 }
 
 fn parse_range(header: &str, total: usize) -> Option<(usize, usize)> {

--- a/crates/awrust-s3-server/src/xml.rs
+++ b/crates/awrust-s3-server/src/xml.rs
@@ -82,6 +82,15 @@ pub struct CompleteMultipartUploadResult {
     pub etag: String,
 }
 
+#[derive(Serialize)]
+#[serde(rename = "CopyObjectResult")]
+pub struct CopyObjectResult {
+    #[serde(rename = "ETag")]
+    pub etag: String,
+    #[serde(rename = "LastModified")]
+    pub last_modified: String,
+}
+
 #[derive(Deserialize)]
 #[serde(rename = "CompleteMultipartUpload")]
 pub struct CompleteMultipartUploadRequest {

--- a/tests/integration/features/copy_object.feature
+++ b/tests/integration/features/copy_object.feature
@@ -1,0 +1,29 @@
+Feature: Copy object
+
+  Background:
+    Given bucket "copy-src" exists
+    And bucket "copy-dst" exists
+
+  Scenario: Copy object within same bucket
+    Given object "copy-src/original.txt" contains "hello"
+    When I copy object "copy-src/original.txt" to "copy-src/duplicate.txt"
+    Then object "copy-src/duplicate.txt" should contain "hello"
+
+  Scenario: Copy object across buckets
+    Given object "copy-src/cross.txt" contains "cross-bucket"
+    When I copy object "copy-src/cross.txt" to "copy-dst/cross.txt"
+    Then object "copy-dst/cross.txt" should contain "cross-bucket"
+
+  Scenario: Copy preserves metadata
+    When I upload "copy-src/meta.txt" with body "data" and metadata "color=red"
+    And I copy object "copy-src/meta.txt" to "copy-dst/meta.txt"
+    Then object "copy-dst/meta.txt" should have metadata "color" with value "red"
+
+  Scenario: Copy preserves content type
+    When I upload "copy-src/typed.json" with body "{}" and content type "application/json"
+    And I copy object "copy-src/typed.json" to "copy-dst/typed.json"
+    Then object "copy-dst/typed.json" should have content type "application/json"
+
+  Scenario: Copy from non-existent source fails
+    When I try to copy object "copy-src/nope.txt" to "copy-dst/nope.txt"
+    Then the operation should fail

--- a/tests/integration/steps/copy_steps.py
+++ b/tests/integration/steps/copy_steps.py
@@ -1,0 +1,33 @@
+from behave import when
+from botocore.exceptions import ClientError
+
+
+def _split(path):
+    bucket, key = path.split("/", 1)
+    return bucket, key
+
+
+@when('I copy object "{src}" to "{dst}"')
+def step_copy_object(context, src, dst):
+    src_bucket, src_key = _split(src)
+    dst_bucket, dst_key = _split(dst)
+    context.copy_response = context.s3.copy_object(
+        Bucket=dst_bucket,
+        Key=dst_key,
+        CopySource=f"{src_bucket}/{src_key}",
+    )
+
+
+@when('I try to copy object "{src}" to "{dst}"')
+def step_try_copy_object(context, src, dst):
+    src_bucket, src_key = _split(src)
+    dst_bucket, dst_key = _split(dst)
+    try:
+        context.s3.copy_object(
+            Bucket=dst_bucket,
+            Key=dst_key,
+            CopySource=f"{src_bucket}/{src_key}",
+        )
+        context.last_error = None
+    except ClientError as e:
+        context.last_error = e


### PR DESCRIPTION
Support `PUT /<bucket>/<key>` with `x-amz-copy-source` header for server-side copy. Used by SDKs for `aws s3 cp s3://src/key s3://dst/key`.

## Implementation & Notes
* Copy is implemented as composition of existing `get_object` → `put_object` → `head_object` — no new `Store` trait method needed. Both MemoryStore and FsStore get copy for free.
* `x-amz-copy-source` is checked first in `put_object_or_part`, before multipart and regular PUT branches.
* Returns `CopyObjectResult` XML with ETag and LastModified, matching the S3 spec.

## How to Test
```bash
cargo test --workspace
cargo fmt --all --check
cargo clippy -- -D warnings
cd tests/integration && behave
cd tests/integration && STORE=fs behave
```

## Suggested Commit Message
```
S3-13 Add copy object support via x-amz-copy-source header (#XX)

PUT requests with x-amz-copy-source now copy bytes, content
type, and metadata from source to destination, returning
CopyObjectResult XML. Implemented as composition of existing
get_object + put_object + head_object — no new Store trait
method needed.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
```

Closes #13