### PR TITLE
S3-14 Add delimiter support to ListObjectsV2

### DIFF
--- a/crates/awrust-s3-domain/src/fs_store.rs
+++ b/crates/awrust-s3-domain/src/fs_store.rs
@@ -1,6 +1,6 @@
 use crate::{
     GetObject, ListObjectsPage, ListObjectsParams, ObjectMeta, ObjectSummary, PutObject, Result,
-    Store, StoreError, composite_etag, decode_continuation_token, encode_continuation_token,
+    Store, StoreError, apply_delimiter, composite_etag, decode_continuation_token,
 };
 use md5::{Digest, Md5};
 use serde::{Deserialize, Serialize};
@@ -273,20 +273,13 @@ impl Store for FsStore {
 
         summaries.sort_by(|a, b| a.key.cmp(&b.key));
 
-        let is_truncated = summaries.len() > params.max_keys;
-        summaries.truncate(params.max_keys);
-
-        let next_continuation_token = if is_truncated {
-            summaries.last().map(|s| encode_continuation_token(&s.key))
-        } else {
-            None
-        };
-
-        Ok(ListObjectsPage {
-            objects: summaries,
-            is_truncated,
-            next_continuation_token,
-        })
+        let prefix = params.prefix.as_deref().unwrap_or("");
+        Ok(apply_delimiter(
+            summaries,
+            prefix,
+            params.delimiter.as_deref(),
+            params.max_keys,
+        ))
     }
 
     fn initiate_multipart(
@@ -488,6 +481,7 @@ mod tests {
                 "b",
                 &ListObjectsParams {
                     prefix: Some("a/".to_string()),
+                    delimiter: None,
                     continuation_token: None,
                     max_keys: 1000,
                 },
@@ -576,6 +570,7 @@ mod tests {
                 "b",
                 &ListObjectsParams {
                     prefix: None,
+                    delimiter: None,
                     continuation_token: None,
                     max_keys: 2,
                 },
@@ -590,6 +585,7 @@ mod tests {
                 "b",
                 &ListObjectsParams {
                     prefix: None,
+                    delimiter: None,
                     continuation_token: page1.next_continuation_token,
                     max_keys: 2,
                 },
@@ -603,6 +599,7 @@ mod tests {
                 "b",
                 &ListObjectsParams {
                     prefix: None,
+                    delimiter: None,
                     continuation_token: page2.next_continuation_token,
                     max_keys: 2,
                 },

--- a/crates/awrust-s3-domain/src/lib.rs
+++ b/crates/awrust-s3-domain/src/lib.rs
@@ -76,12 +76,14 @@ pub struct BucketSummary {
 
 pub struct ListObjectsParams {
     pub prefix: Option<String>,
+    pub delimiter: Option<String>,
     pub continuation_token: Option<String>,
     pub max_keys: usize,
 }
 
 pub struct ListObjectsPage {
     pub objects: Vec<ObjectSummary>,
+    pub common_prefixes: Vec<String>,
     pub is_truncated: bool,
     pub next_continuation_token: Option<String>,
 }
@@ -175,6 +177,72 @@ fn composite_etag(part_digests: &[Vec<u8>]) -> String {
         hasher.update(digest);
     }
     format!("\"{:x}-{}\"", hasher.finalize(), part_digests.len())
+}
+
+fn apply_delimiter(
+    sorted: Vec<ObjectSummary>,
+    prefix: &str,
+    delimiter: Option<&str>,
+    max_keys: usize,
+) -> ListObjectsPage {
+    let Some(delim) = delimiter else {
+        let is_truncated = sorted.len() > max_keys;
+        let mut objects = sorted;
+        objects.truncate(max_keys);
+        let next_continuation_token = if is_truncated {
+            objects.last().map(|s| encode_continuation_token(&s.key))
+        } else {
+            None
+        };
+        return ListObjectsPage {
+            objects,
+            common_prefixes: Vec::new(),
+            is_truncated,
+            next_continuation_token,
+        };
+    };
+
+    let mut objects = Vec::new();
+    let mut prefixes = std::collections::BTreeSet::new();
+    let mut last_key_seen = String::new();
+
+    for obj in &sorted {
+        last_key_seen.clone_from(&obj.key);
+        let after = &obj.key[prefix.len()..];
+        if let Some(pos) = after.find(delim) {
+            let cp = format!("{}{}", prefix, &after[..pos + delim.len()]);
+            let is_new = prefixes.insert(cp);
+            if is_new && objects.len() + prefixes.len() > max_keys {
+                break;
+            }
+        } else {
+            objects.push(obj.clone());
+            if objects.len() + prefixes.len() > max_keys {
+                break;
+            }
+        }
+    }
+
+    let total = objects.len() + prefixes.len();
+    let is_truncated = total > max_keys;
+    objects.truncate(max_keys.saturating_sub(prefixes.len()));
+    let common_prefixes: Vec<String> = prefixes
+        .into_iter()
+        .take(max_keys - objects.len())
+        .collect();
+
+    let next_continuation_token = if is_truncated {
+        Some(encode_continuation_token(&last_key_seen))
+    } else {
+        None
+    };
+
+    ListObjectsPage {
+        objects,
+        common_prefixes,
+        is_truncated,
+        next_continuation_token,
+    }
 }
 
 fn encode_continuation_token(key: &str) -> String {
@@ -350,20 +418,13 @@ impl Store for MemoryStore {
 
         summaries.sort_by(|a, b| a.key.cmp(&b.key));
 
-        let is_truncated = summaries.len() > params.max_keys;
-        summaries.truncate(params.max_keys);
-
-        let next_continuation_token = if is_truncated {
-            summaries.last().map(|s| encode_continuation_token(&s.key))
-        } else {
-            None
-        };
-
-        Ok(ListObjectsPage {
-            objects: summaries,
-            is_truncated,
-            next_continuation_token,
-        })
+        let prefix = params.prefix.as_deref().unwrap_or("");
+        Ok(apply_delimiter(
+            summaries,
+            prefix,
+            params.delimiter.as_deref(),
+            params.max_keys,
+        ))
     }
 
     fn initiate_multipart(

--- a/crates/awrust-s3-domain/tests/memory_store.rs
+++ b/crates/awrust-s3-domain/tests/memory_store.rs
@@ -100,6 +100,7 @@ fn list_with_prefix() {
             "bucket",
             &ListObjectsParams {
                 prefix: Some("a/".to_string()),
+                delimiter: None,
                 continuation_token: None,
                 max_keys: 1000,
             },
@@ -168,6 +169,7 @@ fn pagination() {
             "bucket",
             &ListObjectsParams {
                 prefix: None,
+                delimiter: None,
                 continuation_token: None,
                 max_keys: 2,
             },
@@ -182,6 +184,7 @@ fn pagination() {
             "bucket",
             &ListObjectsParams {
                 prefix: None,
+                delimiter: None,
                 continuation_token: page1.next_continuation_token,
                 max_keys: 2,
             },
@@ -195,6 +198,7 @@ fn pagination() {
             "bucket",
             &ListObjectsParams {
                 prefix: None,
+                delimiter: None,
                 continuation_token: page2.next_continuation_token,
                 max_keys: 2,
             },
@@ -202,4 +206,80 @@ fn pagination() {
         .unwrap();
     assert_eq!(page3.objects.len(), 1);
     assert!(!page3.is_truncated);
+}
+
+#[test]
+fn delimiter_groups_nested_keys() {
+    let store = MemoryStore::new();
+    store.create_bucket("bucket").unwrap();
+    put(&store, "bucket", "a.txt", b"one");
+    put(&store, "bucket", "dir/b.txt", b"two");
+    put(&store, "bucket", "dir/c.txt", b"three");
+    put(&store, "bucket", "dir/sub/d.txt", b"four");
+
+    let page = store
+        .list_objects(
+            "bucket",
+            &ListObjectsParams {
+                prefix: None,
+                delimiter: Some("/".to_string()),
+                continuation_token: None,
+                max_keys: 1000,
+            },
+        )
+        .unwrap();
+
+    let keys: Vec<&str> = page.objects.iter().map(|o| o.key.as_str()).collect();
+    assert_eq!(keys, vec!["a.txt"]);
+    assert_eq!(page.common_prefixes, vec!["dir/"]);
+    assert!(!page.is_truncated);
+}
+
+#[test]
+fn delimiter_with_prefix() {
+    let store = MemoryStore::new();
+    store.create_bucket("bucket").unwrap();
+    put(&store, "bucket", "photos/a.jpg", b"one");
+    put(&store, "bucket", "photos/vacation/b.jpg", b"two");
+    put(&store, "bucket", "photos/vacation/c.jpg", b"three");
+
+    let page = store
+        .list_objects(
+            "bucket",
+            &ListObjectsParams {
+                prefix: Some("photos/".to_string()),
+                delimiter: Some("/".to_string()),
+                continuation_token: None,
+                max_keys: 1000,
+            },
+        )
+        .unwrap();
+
+    let keys: Vec<&str> = page.objects.iter().map(|o| o.key.as_str()).collect();
+    assert_eq!(keys, vec!["photos/a.jpg"]);
+    assert_eq!(page.common_prefixes, vec!["photos/vacation/"]);
+}
+
+#[test]
+fn delimiter_without_matches_returns_all_as_contents() {
+    let store = MemoryStore::new();
+    store.create_bucket("bucket").unwrap();
+    put(&store, "bucket", "a.txt", b"one");
+    put(&store, "bucket", "b.txt", b"two");
+
+    let page = store
+        .list_objects(
+            "bucket",
+            &ListObjectsParams {
+                prefix: None,
+                delimiter: Some("/".to_string()),
+                continuation_token: None,
+                max_keys: 1000,
+            },
+        )
+        .unwrap();
+
+    let keys: Vec<&str> = page.objects.iter().map(|o| o.key.as_str()).collect();
+    assert_eq!(keys, vec!["a.txt", "b.txt"]);
+    assert!(page.common_prefixes.is_empty());
 }

--- a/crates/awrust-s3-server/src/handlers.rs
+++ b/crates/awrust-s3-server/src/handlers.rs
@@ -10,9 +10,9 @@ use std::time::{Duration, UNIX_EPOCH};
 
 use crate::error::S3Error;
 use crate::xml::{
-    BucketEntry, BucketList, CompleteMultipartUploadResult, CopyObjectResult, DeleteErrorEntry,
-    DeleteResult, DeletedEntry, InitiateMultipartUploadResult, ListAllMyBucketsResult,
-    ListBucketResult, ObjectEntry, XmlResponse,
+    BucketEntry, BucketList, CommonPrefix, CompleteMultipartUploadResult, CopyObjectResult,
+    DeleteErrorEntry, DeleteResult, DeletedEntry, InitiateMultipartUploadResult,
+    ListAllMyBucketsResult, ListBucketResult, ObjectEntry, XmlResponse,
 };
 
 type S3Result<T> = Result<T, S3Error>;
@@ -111,6 +111,7 @@ pub async fn list_buckets(State(store): State<Arc<dyn Store>>) -> Response {
 #[derive(Deserialize, Default)]
 pub struct ListParams {
     pub prefix: Option<String>,
+    pub delimiter: Option<String>,
     #[serde(rename = "max-keys")]
     pub max_keys: Option<usize>,
     #[serde(rename = "continuation-token")]
@@ -127,6 +128,7 @@ pub async fn list_objects(
         &bucket,
         &ListObjectsParams {
             prefix: params.prefix.clone(),
+            delimiter: params.delimiter.clone(),
             continuation_token: params.continuation_token.clone(),
             max_keys,
         },
@@ -135,7 +137,8 @@ pub async fn list_objects(
     let result = ListBucketResult {
         name: bucket,
         prefix: params.prefix.unwrap_or_default(),
-        key_count: page.objects.len(),
+        delimiter: params.delimiter,
+        key_count: page.objects.len() + page.common_prefixes.len(),
         max_keys,
         is_truncated: page.is_truncated,
         continuation_token: params.continuation_token,
@@ -149,6 +152,11 @@ pub async fn list_objects(
                 size: o.size,
                 etag: o.etag,
             })
+            .collect(),
+        common_prefixes: page
+            .common_prefixes
+            .into_iter()
+            .map(|p| CommonPrefix { prefix: p })
             .collect(),
     };
 

--- a/crates/awrust-s3-server/src/xml.rs
+++ b/crates/awrust-s3-server/src/xml.rs
@@ -10,6 +10,8 @@ pub struct ListBucketResult {
     pub name: String,
     #[serde(rename = "Prefix")]
     pub prefix: String,
+    #[serde(rename = "Delimiter", skip_serializing_if = "Option::is_none")]
+    pub delimiter: Option<String>,
     #[serde(rename = "KeyCount")]
     pub key_count: usize,
     #[serde(rename = "MaxKeys")]
@@ -25,6 +27,18 @@ pub struct ListBucketResult {
     pub next_continuation_token: Option<String>,
     #[serde(rename = "Contents", default)]
     pub contents: Vec<ObjectEntry>,
+    #[serde(
+        rename = "CommonPrefixes",
+        default,
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub common_prefixes: Vec<CommonPrefix>,
+}
+
+#[derive(Serialize)]
+pub struct CommonPrefix {
+    #[serde(rename = "Prefix")]
+    pub prefix: String,
 }
 
 #[derive(Serialize)]

--- a/tests/integration/features/delimiter.feature
+++ b/tests/integration/features/delimiter.feature
@@ -1,0 +1,28 @@
+Feature: ListObjectsV2 delimiter support
+
+  Background:
+    Given bucket "delim-bucket" exists
+
+  Scenario: Delimiter groups nested keys into common prefixes
+    Given object "delim-bucket/a.txt" contains "data"
+    And object "delim-bucket/dir/b.txt" contains "data"
+    And object "delim-bucket/dir/c.txt" contains "data"
+    And object "delim-bucket/dir/sub/d.txt" contains "data"
+    When I list objects in "delim-bucket" using delimiter "/"
+    Then the content keys should be "a.txt"
+    And the common prefix list should be "dir/"
+
+  Scenario: Prefix with delimiter returns correct split
+    Given object "delim-bucket/photos/a.jpg" contains "data"
+    And object "delim-bucket/photos/vacation/b.jpg" contains "data"
+    And object "delim-bucket/photos/vacation/c.jpg" contains "data"
+    When I list objects in "delim-bucket" using prefix "photos/" and delimiter "/"
+    Then the content keys should be "photos/a.jpg"
+    And the common prefix list should be "photos/vacation/"
+
+  Scenario: No delimiter returns all keys as contents
+    Given object "delim-bucket/x/a.txt" contains "data"
+    And object "delim-bucket/x/b.txt" contains "data"
+    When I list objects in "delim-bucket" using prefix "x/" without delimiter
+    Then the content keys should be "x/a.txt,x/b.txt"
+    And the common prefix list should be empty

--- a/tests/integration/steps/delimiter_steps.py
+++ b/tests/integration/steps/delimiter_steps.py
@@ -1,0 +1,42 @@
+from behave import when, then
+
+
+@when('I list objects in "{bucket}" using delimiter "{delimiter}"')
+def step_list_with_delimiter(context, bucket, delimiter):
+    context._delim_response = context.s3.list_objects_v2(
+        Bucket=bucket, Delimiter=delimiter,
+    )
+
+
+@when('I list objects in "{bucket}" using prefix "{prefix}" and delimiter "{delimiter}"')
+def step_list_with_prefix_and_delimiter(context, bucket, prefix, delimiter):
+    context._delim_response = context.s3.list_objects_v2(
+        Bucket=bucket, Prefix=prefix, Delimiter=delimiter,
+    )
+
+
+@when('I list objects in "{bucket}" using prefix "{prefix}" without delimiter')
+def step_list_without_delimiter(context, bucket, prefix):
+    context._delim_response = context.s3.list_objects_v2(
+        Bucket=bucket, Prefix=prefix,
+    )
+
+
+@then('the content keys should be "{expected_keys}"')
+def step_assert_content_keys(context, expected_keys):
+    expected = sorted(expected_keys.split(","))
+    actual = sorted(o["Key"] for o in context._delim_response.get("Contents", []))
+    assert actual == expected, f"expected {expected}, got {actual}"
+
+
+@then('the common prefix list should be "{expected_prefixes}"')
+def step_assert_common_prefix_list(context, expected_prefixes):
+    expected = sorted(expected_prefixes.split(","))
+    actual = sorted(p["Prefix"] for p in context._delim_response.get("CommonPrefixes", []))
+    assert actual == expected, f"expected {expected}, got {actual}"
+
+
+@then("the common prefix list should be empty")
+def step_assert_no_common_prefixes(context):
+    prefixes = context._delim_response.get("CommonPrefixes", [])
+    assert len(prefixes) == 0, f"expected no common prefixes, got {prefixes}"


### PR DESCRIPTION
Enables folder-like browsing by supporting the `delimiter` query parameter in ListObjectsV2, returning `CommonPrefixes` for grouped keys.

## Implementation & Notes
* Added `delimiter` field to `ListObjectsParams` and `common_prefixes` to `ListObjectsPage` in the domain layer
* Extracted a shared `apply_delimiter()` function that partitions sorted keys into contents vs common prefixes using a `BTreeSet` for deduplication — used by both MemoryStore and FsStore, replacing their duplicated pagination logic
* Server layer passes delimiter through from query params and serializes `<CommonPrefixes><Prefix>` and `<Delimiter>` in the XML response
* `KeyCount` now includes both contents and common prefixes, matching real S3 behaviour

## How to Test
```bash
cargo test --workspace
cd tests/integration && behave features/delimiter.feature
```

Manual smoke test:
```bash
aws --endpoint-url http://localhost:4566 s3 mb s3://test
aws --endpoint-url http://localhost:4566 s3 cp /etc/hosts s3://test/dir/hosts
aws --endpoint-url http://localhost:4566 s3 ls s3://test/
```

## Suggested Commit Message
```
S3-14 Add delimiter support to ListObjectsV2 (#XX)

Enable folder-like browsing by accepting the delimiter query
parameter and returning CommonPrefixes in the XML response.
A shared apply_delimiter function handles the partitioning
logic for both MemoryStore and FsStore.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
```