### PR TITLE
S3-15 Add bucket location endpoint

### DIFF
--- a/crates/awrust-s3-server/src/handlers.rs
+++ b/crates/awrust-s3-server/src/handlers.rs
@@ -1,6 +1,6 @@
 use awrust_s3_domain::{ListObjectsParams, ObjectMeta, PutObject, Store};
 use axum::body::Bytes;
-use axum::extract::{Path, Query, State};
+use axum::extract::{Path, Query, RawQuery, State};
 use axum::http::{HeaderMap, HeaderName, StatusCode};
 use axum::response::{IntoResponse, Response};
 use serde::Deserialize;
@@ -12,7 +12,7 @@ use crate::error::S3Error;
 use crate::xml::{
     BucketEntry, BucketList, CommonPrefix, CompleteMultipartUploadResult, CopyObjectResult,
     DeleteErrorEntry, DeleteResult, DeletedEntry, InitiateMultipartUploadResult,
-    ListAllMyBucketsResult, ListBucketResult, ObjectEntry, XmlResponse,
+    ListAllMyBucketsResult, ListBucketResult, LocationConstraint, ObjectEntry, XmlResponse,
 };
 
 type S3Result<T> = Result<T, S3Error>;
@@ -116,6 +116,31 @@ pub struct ListParams {
     pub max_keys: Option<usize>,
     #[serde(rename = "continuation-token")]
     pub continuation_token: Option<String>,
+}
+
+pub async fn get_bucket(
+    state: State<Arc<dyn Store>>,
+    path: Path<String>,
+    RawQuery(query): RawQuery,
+    params: Query<ListParams>,
+) -> S3Result<Response> {
+    if query.as_deref() == Some("location") {
+        return get_bucket_location(state, path).await;
+    }
+    list_objects(state, path, params).await
+}
+
+async fn get_bucket_location(
+    State(store): State<Arc<dyn Store>>,
+    Path(bucket): Path<String>,
+) -> S3Result<Response> {
+    if !store.bucket_exists(&bucket) {
+        return Err(awrust_s3_domain::StoreError::BucketNotFound(bucket).into());
+    }
+    Ok(XmlResponse(LocationConstraint {
+        region: "us-east-1".to_string(),
+    })
+    .into_response())
 }
 
 pub async fn list_objects(

--- a/crates/awrust-s3-server/src/main.rs
+++ b/crates/awrust-s3-server/src/main.rs
@@ -47,7 +47,7 @@ async fn main() {
             put(handlers::create_bucket)
                 .head(handlers::head_bucket)
                 .delete(handlers::delete_bucket)
-                .get(handlers::list_objects)
+                .get(handlers::get_bucket)
                 .post(handlers::post_bucket),
         )
         .route(

--- a/crates/awrust-s3-server/src/xml.rs
+++ b/crates/awrust-s3-server/src/xml.rs
@@ -160,6 +160,13 @@ pub struct DeleteErrorEntry {
     pub message: String,
 }
 
+#[derive(Serialize)]
+#[serde(rename = "LocationConstraint")]
+pub struct LocationConstraint {
+    #[serde(rename = "$text")]
+    pub region: String,
+}
+
 pub struct XmlResponse<T: Serialize>(pub T);
 
 impl<T: Serialize> IntoResponse for XmlResponse<T> {
@@ -171,5 +178,20 @@ impl<T: Serialize> IntoResponse for XmlResponse<T> {
             }
             Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quick_xml::se::to_string;
+
+    #[test]
+    fn location_constraint_serializes_region() {
+        let lc = LocationConstraint {
+            region: "us-east-1".to_string(),
+        };
+        let xml = to_string(&lc).unwrap();
+        assert_eq!(xml, "<LocationConstraint>us-east-1</LocationConstraint>");
     }
 }

--- a/tests/integration/features/bucket.feature
+++ b/tests/integration/features/bucket.feature
@@ -31,3 +31,12 @@ Feature: Bucket operations
     Given bucket "dated-bucket" exists
     When I list all buckets
     Then bucket "dated-bucket" in the list should have a creation date
+
+  Scenario: Get bucket location
+    Given bucket "loc-bucket" exists
+    When I get the location of bucket "loc-bucket"
+    Then the location should be "us-east-1"
+
+  Scenario: Get location of non-existent bucket fails
+    When I try to get the location of bucket "ghost-bucket"
+    Then the operation should fail

--- a/tests/integration/steps/bucket_steps.py
+++ b/tests/integration/steps/bucket_steps.py
@@ -61,3 +61,25 @@ def step_assert_bucket_has_creation_date(context, name):
             assert "CreationDate" in b, f"bucket {name} missing CreationDate"
             return
     assert False, f"bucket {name} not found in list"
+
+
+@when('I get the location of bucket "{name}"')
+def step_get_bucket_location(context, name):
+    resp = context.s3.get_bucket_location(Bucket=name)
+    context.location = resp.get("LocationConstraint")
+
+
+@when('I try to get the location of bucket "{name}"')
+def step_try_get_bucket_location(context, name):
+    try:
+        context.s3.get_bucket_location(Bucket=name)
+        context.last_error = None
+    except ClientError as e:
+        context.last_error = e
+
+
+@then('the location should be "{region}"')
+def step_assert_location(context, region):
+    assert context.location == region, (
+        f"expected {region}, got {context.location}"
+    )


### PR DESCRIPTION
Adds `GET /<bucket>?location` returning a fixed `us-east-1` region, enabling SDK client setup flows that probe bucket location.

## Implementation & Notes
* Introduces a `get_bucket` dispatcher on the `GET /:bucket` route that checks the raw query string for `?location` via `RawQuery`, delegating to `list_objects` for all other queries.
* `get_bucket_location` validates bucket existence (404 if missing) and returns `<LocationConstraint>us-east-1</LocationConstraint>` XML.
* `LocationConstraint` XML struct uses quick-xml `$text` serde rename for text content serialization.
* No domain crate changes — region is a constant, not stored data. No new dependencies.

## How to Test
```bash
cargo test --workspace
cd tests/integration && behave
```
New BDD scenarios:
* "Get bucket location" — creates a bucket, calls `get_bucket_location`, asserts `us-east-1`
* "Get location of non-existent bucket fails" — asserts 404

## Suggested Commit Message
```
S3-15 Add bucket location endpoint (GET /<bucket>?location) (#XX)

SDKs call GET /<bucket>?location during client setup and
fail without it. This adds a get_bucket dispatcher on the
GET /:bucket route that checks for ?location via RawQuery
and returns <LocationConstraint>us-east-1</LocationConstraint>
XML, or delegates to list_objects for all other queries.
Returns 404 if the bucket does not exist.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
```

Closes #15