### PR TITLE
S3-16 Presigned URL support

### DIFF
--- a/tests/integration/features/presigned.feature
+++ b/tests/integration/features/presigned.feature
@@ -1,0 +1,13 @@
+Feature: Presigned URL support
+
+  Background:
+    Given bucket "presigned-bucket" exists
+
+  Scenario: PUT object via presigned URL
+    When I upload "presigned-bucket/put-test.txt" via presigned URL with content "presigned put"
+    Then object "presigned-bucket/put-test.txt" should contain "presigned put"
+
+  Scenario: GET object via presigned URL
+    Given object "presigned-bucket/get-test.txt" contains "presigned get"
+    When I download "presigned-bucket/get-test.txt" via presigned URL
+    Then the presigned response should contain "presigned get"

--- a/tests/integration/steps/presigned_steps.py
+++ b/tests/integration/steps/presigned_steps.py
@@ -1,0 +1,40 @@
+import urllib.request
+
+from behave import when, then
+
+
+def _split(path):
+    bucket, key = path.split("/", 1)
+    return bucket, key
+
+
+@when('I upload "{path}" via presigned URL with content "{content}"')
+def step_put_presigned(context, path, content):
+    bucket, key = _split(path)
+    url = context.s3.generate_presigned_url(
+        "put_object",
+        Params={"Bucket": bucket, "Key": key},
+        ExpiresIn=3600,
+    )
+    req = urllib.request.Request(url, data=content.encode(), method="PUT")
+    with urllib.request.urlopen(req) as resp:
+        context.presigned_status = resp.status
+
+
+@when('I download "{path}" via presigned URL')
+def step_get_presigned(context, path):
+    bucket, key = _split(path)
+    url = context.s3.generate_presigned_url(
+        "get_object",
+        Params={"Bucket": bucket, "Key": key},
+        ExpiresIn=3600,
+    )
+    with urllib.request.urlopen(url) as resp:
+        context.presigned_body = resp.read().decode()
+
+
+@then('the presigned response should contain "{expected}"')
+def step_assert_presigned_content(context, expected):
+    assert context.presigned_body == expected, (
+        f"expected {expected!r}, got {context.presigned_body!r}"
+    )


### PR DESCRIPTION
Accept requests with presigned URL query parameters by verifying that serde's default behavior of ignoring unknown fields handles X-Amz-* params transparently.

## Implementation & Notes
* No server code changes required — Axum's `Query` extractor uses `serde_urlencoded` which ignores unknown fields by default, and handlers without `Query` don't parse query params at all.
* Added BDD feature with two scenarios: PUT and GET via boto3 `generate_presigned_url()`, exercised through raw `urllib.request` to ensure the full presigned URL (with auth query params) reaches the server.

## How to Test
```bash
cd tests/integration
behave features/presigned.feature
```

## Suggested Commit Message
```
S3-16 Add presigned URL support (#XX)

Presigned URLs with X-Amz-* query params already work
because serde ignores unknown fields. BDD tests added
to verify PUT and GET via generate_presigned_url.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code "Claude Code")