### PR TITLE
S3-17 Add ListMultipartUploads (GET /<bucket>?uploads)

### DIFF
--- a/crates/awrust-s3-domain/src/fs_store.rs
+++ b/crates/awrust-s3-domain/src/fs_store.rs
@@ -1,6 +1,6 @@
 use crate::{
     GetObject, ListObjectsPage, ListObjectsParams, ObjectMeta, ObjectSummary, PutObject, Result,
-    Store, StoreError, apply_delimiter, composite_etag, decode_continuation_token,
+    Store, StoreError, UploadSummary, apply_delimiter, composite_etag, decode_continuation_token,
 };
 use md5::{Digest, Md5};
 use serde::{Deserialize, Serialize};
@@ -28,6 +28,8 @@ struct UploadMeta {
     key: String,
     content_type: String,
     metadata: HashMap<String, String>,
+    #[serde(default)]
+    initiated: u64,
 }
 
 fn encode_key(key: &str) -> String {
@@ -300,6 +302,7 @@ impl Store for FsStore {
             key: key.to_string(),
             content_type: content_type.to_string(),
             metadata,
+            initiated: now_secs(),
         };
         let meta_json = serde_json::to_vec(&meta).expect("serialize upload meta");
         fs::write(upload_dir.join("meta.json"), &meta_json).expect("write upload meta");
@@ -383,6 +386,41 @@ impl Store for FsStore {
         }
         fs::remove_dir_all(&upload_dir).ok();
         Ok(())
+    }
+
+    fn list_multipart_uploads(
+        &self,
+        bucket: &str,
+        prefix: Option<&str>,
+    ) -> Result<Vec<UploadSummary>> {
+        self.require_bucket(bucket)?;
+
+        let uploads_dir = self.uploads_dir(bucket);
+        let mut summaries: Vec<UploadSummary> = fs::read_dir(&uploads_dir)
+            .into_iter()
+            .flatten()
+            .filter_map(|entry| {
+                let entry = entry.ok()?;
+                let upload_id = entry.file_name().into_string().ok()?;
+                let meta_path = entry.path().join("meta.json");
+                let data = fs::read(&meta_path).ok()?;
+                let meta: UploadMeta = serde_json::from_slice(&data).ok()?;
+
+                if let Some(pfx) = prefix
+                    && !meta.key.starts_with(pfx)
+                {
+                    return None;
+                }
+
+                Some(UploadSummary {
+                    key: meta.key,
+                    upload_id,
+                    initiated: meta.initiated,
+                })
+            })
+            .collect();
+        summaries.sort_by(|a, b| a.key.cmp(&b.key));
+        Ok(summaries)
     }
 }
 
@@ -607,5 +645,30 @@ mod tests {
             .unwrap();
         assert_eq!(page3.objects.len(), 1);
         assert!(!page3.is_truncated);
+    }
+
+    #[test]
+    fn list_multipart_uploads() {
+        let (_tmp, store) = setup();
+        store.create_bucket("b").unwrap();
+
+        let id1 = store
+            .initiate_multipart("b", "photos/cat.jpg", "image/jpeg", HashMap::new())
+            .unwrap();
+        let id2 = store
+            .initiate_multipart("b", "docs/readme.md", "text/plain", HashMap::new())
+            .unwrap();
+
+        let uploads = store.list_multipart_uploads("b", None).unwrap();
+        assert_eq!(uploads.len(), 2);
+        assert_eq!(uploads[0].key, "docs/readme.md");
+        assert_eq!(uploads[0].upload_id, id2);
+        assert!(uploads[0].initiated > 0);
+        assert_eq!(uploads[1].key, "photos/cat.jpg");
+        assert_eq!(uploads[1].upload_id, id1);
+
+        let filtered = store.list_multipart_uploads("b", Some("docs/")).unwrap();
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].key, "docs/readme.md");
     }
 }

--- a/crates/awrust-s3-domain/src/lib.rs
+++ b/crates/awrust-s3-domain/src/lib.rs
@@ -88,6 +88,13 @@ pub struct ListObjectsPage {
     pub next_continuation_token: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UploadSummary {
+    pub key: String,
+    pub upload_id: String,
+    pub initiated: u64,
+}
+
 pub trait Store: Send + Sync {
     fn create_bucket(&self, name: &str) -> Result<()>;
     fn bucket_exists(&self, name: &str) -> bool;
@@ -123,6 +130,11 @@ pub trait Store: Send + Sync {
         parts: &[(u32, String)],
     ) -> Result<String>;
     fn abort_multipart(&self, bucket: &str, key: &str, upload_id: &str) -> Result<()>;
+    fn list_multipart_uploads(
+        &self,
+        bucket: &str,
+        prefix: Option<&str>,
+    ) -> Result<Vec<UploadSummary>>;
 }
 
 #[derive(Debug, Default)]
@@ -162,6 +174,7 @@ struct InFlightUpload {
     content_type: String,
     metadata: HashMap<String, String>,
     parts: HashMap<u32, Vec<u8>>,
+    initiated: u64,
 }
 
 fn now_secs() -> u64 {
@@ -448,6 +461,7 @@ impl Store for MemoryStore {
                 content_type: content_type.to_string(),
                 metadata,
                 parts: HashMap::new(),
+                initiated: now_secs(),
             },
         );
         Ok(upload_id)
@@ -526,5 +540,123 @@ impl Store for MemoryStore {
             .remove(upload_id)
             .ok_or_else(|| StoreError::UploadNotFound(upload_id.to_string()))?;
         Ok(())
+    }
+
+    fn list_multipart_uploads(
+        &self,
+        bucket: &str,
+        prefix: Option<&str>,
+    ) -> Result<Vec<UploadSummary>> {
+        if !self.bucket_exists(bucket) {
+            return Err(StoreError::BucketNotFound(bucket.to_string()));
+        }
+
+        let uploads = self.uploads.read().expect("lock poisoned");
+        let mut summaries: Vec<UploadSummary> = uploads
+            .iter()
+            .filter(|(_, u)| u.bucket == bucket)
+            .filter(|(_, u)| match prefix {
+                Some(pfx) => u.key.starts_with(pfx),
+                None => true,
+            })
+            .map(|(id, u)| UploadSummary {
+                key: u.key.clone(),
+                upload_id: id.clone(),
+                initiated: u.initiated,
+            })
+            .collect();
+        summaries.sort_by(|a, b| a.key.cmp(&b.key));
+        Ok(summaries)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_multipart_uploads_empty() {
+        let store = MemoryStore::new();
+        store.create_bucket("b").unwrap();
+        let uploads = store.list_multipart_uploads("b", None).unwrap();
+        assert!(uploads.is_empty());
+    }
+
+    #[test]
+    fn list_multipart_uploads_returns_active() {
+        let store = MemoryStore::new();
+        store.create_bucket("b").unwrap();
+        let id1 = store
+            .initiate_multipart("b", "photos/cat.jpg", "image/jpeg", HashMap::new())
+            .unwrap();
+        let id2 = store
+            .initiate_multipart("b", "docs/readme.md", "text/plain", HashMap::new())
+            .unwrap();
+
+        let uploads = store.list_multipart_uploads("b", None).unwrap();
+        assert_eq!(uploads.len(), 2);
+        assert_eq!(uploads[0].key, "docs/readme.md");
+        assert_eq!(uploads[0].upload_id, id2);
+        assert!(uploads[0].initiated > 0);
+        assert_eq!(uploads[1].key, "photos/cat.jpg");
+        assert_eq!(uploads[1].upload_id, id1);
+    }
+
+    #[test]
+    fn list_multipart_uploads_filters_by_prefix() {
+        let store = MemoryStore::new();
+        store.create_bucket("b").unwrap();
+        store
+            .initiate_multipart("b", "photos/cat.jpg", "image/jpeg", HashMap::new())
+            .unwrap();
+        store
+            .initiate_multipart("b", "docs/readme.md", "text/plain", HashMap::new())
+            .unwrap();
+
+        let uploads = store.list_multipart_uploads("b", Some("photos/")).unwrap();
+        assert_eq!(uploads.len(), 1);
+        assert_eq!(uploads[0].key, "photos/cat.jpg");
+    }
+
+    #[test]
+    fn list_multipart_uploads_excludes_completed() {
+        let store = MemoryStore::new();
+        store.create_bucket("b").unwrap();
+        let id = store
+            .initiate_multipart("b", "key", "application/octet-stream", HashMap::new())
+            .unwrap();
+        let etag = store
+            .upload_part("b", "key", &id, 1, b"data".to_vec())
+            .unwrap();
+        store
+            .complete_multipart("b", "key", &id, &[(1, etag)])
+            .unwrap();
+
+        let uploads = store.list_multipart_uploads("b", None).unwrap();
+        assert!(uploads.is_empty());
+    }
+
+    #[test]
+    fn list_multipart_uploads_bucket_not_found() {
+        let store = MemoryStore::new();
+        let result = store.list_multipart_uploads("nope", None);
+        assert!(matches!(result, Err(StoreError::BucketNotFound(_))));
+    }
+
+    #[test]
+    fn list_multipart_uploads_scoped_to_bucket() {
+        let store = MemoryStore::new();
+        store.create_bucket("a").unwrap();
+        store.create_bucket("b").unwrap();
+        store
+            .initiate_multipart("a", "key-a", "text/plain", HashMap::new())
+            .unwrap();
+        store
+            .initiate_multipart("b", "key-b", "text/plain", HashMap::new())
+            .unwrap();
+
+        let uploads = store.list_multipart_uploads("a", None).unwrap();
+        assert_eq!(uploads.len(), 1);
+        assert_eq!(uploads[0].key, "key-a");
     }
 }

--- a/crates/awrust-s3-server/src/handlers.rs
+++ b/crates/awrust-s3-server/src/handlers.rs
@@ -12,7 +12,8 @@ use crate::error::S3Error;
 use crate::xml::{
     BucketEntry, BucketList, CommonPrefix, CompleteMultipartUploadResult, CopyObjectResult,
     DeleteErrorEntry, DeleteResult, DeletedEntry, InitiateMultipartUploadResult,
-    ListAllMyBucketsResult, ListBucketResult, LocationConstraint, ObjectEntry, XmlResponse,
+    ListAllMyBucketsResult, ListBucketResult, ListMultipartUploadsResult, LocationConstraint,
+    ObjectEntry, UploadEntry, XmlResponse,
 };
 
 type S3Result<T> = Result<T, S3Error>;
@@ -116,6 +117,7 @@ pub struct ListParams {
     pub max_keys: Option<usize>,
     #[serde(rename = "continuation-token")]
     pub continuation_token: Option<String>,
+    pub uploads: Option<String>,
 }
 
 pub async fn get_bucket(
@@ -148,6 +150,23 @@ pub async fn list_objects(
     Path(bucket): Path<String>,
     Query(params): Query<ListParams>,
 ) -> S3Result<Response> {
+    if params.uploads.is_some() {
+        let summaries = store.list_multipart_uploads(&bucket, params.prefix.as_deref())?;
+        let result = ListMultipartUploadsResult {
+            bucket,
+            prefix: params.prefix.unwrap_or_default(),
+            uploads: summaries
+                .into_iter()
+                .map(|u| UploadEntry {
+                    key: u.key,
+                    upload_id: u.upload_id,
+                    initiated: format_iso8601(u.initiated),
+                })
+                .collect(),
+        };
+        return Ok(XmlResponse(result).into_response());
+    }
+
     let max_keys = params.max_keys.unwrap_or(1000);
     let page = store.list_objects(
         &bucket,

--- a/crates/awrust-s3-server/src/xml.rs
+++ b/crates/awrust-s3-server/src/xml.rs
@@ -105,6 +105,27 @@ pub struct CopyObjectResult {
     pub last_modified: String,
 }
 
+#[derive(Serialize)]
+#[serde(rename = "ListMultipartUploadsResult")]
+pub struct ListMultipartUploadsResult {
+    #[serde(rename = "Bucket")]
+    pub bucket: String,
+    #[serde(rename = "Prefix")]
+    pub prefix: String,
+    #[serde(rename = "Upload", default, skip_serializing_if = "Vec::is_empty")]
+    pub uploads: Vec<UploadEntry>,
+}
+
+#[derive(Serialize)]
+pub struct UploadEntry {
+    #[serde(rename = "Key")]
+    pub key: String,
+    #[serde(rename = "UploadId")]
+    pub upload_id: String,
+    #[serde(rename = "Initiated")]
+    pub initiated: String,
+}
+
 #[derive(Deserialize)]
 #[serde(rename = "CompleteMultipartUpload")]
 pub struct CompleteMultipartUploadRequest {

--- a/tests/integration/features/list_uploads.feature
+++ b/tests/integration/features/list_uploads.feature
@@ -1,0 +1,18 @@
+Feature: List multipart uploads
+  As an S3 client
+  I want to list in-progress multipart uploads
+  So that I can manage or clean them up
+
+  Scenario: List active multipart uploads
+    Given bucket "lu-bucket" exists
+    When I initiate a multipart upload for "lu-bucket/photos/cat.jpg"
+    And I initiate a multipart upload for "lu-bucket/docs/readme.md"
+    Then listing multipart uploads in "lu-bucket" returns 2 uploads
+    And the upload keys include "photos/cat.jpg" and "docs/readme.md"
+
+  Scenario: List uploads filtered by prefix
+    Given bucket "lu-prefix" exists
+    When I initiate a multipart upload for "lu-prefix/photos/cat.jpg"
+    And I initiate a multipart upload for "lu-prefix/docs/readme.md"
+    Then listing multipart uploads in "lu-prefix" with prefix "photos/" returns 1 upload
+    And the upload key is "photos/cat.jpg"

--- a/tests/integration/steps/list_uploads_steps.py
+++ b/tests/integration/steps/list_uploads_steps.py
@@ -1,0 +1,38 @@
+from behave import then
+
+
+def _split(path):
+    bucket, key = path.split("/", 1)
+    return bucket, key
+
+
+@then('listing multipart uploads in "{bucket}" returns {n:d} uploads')
+def step_list_uploads(context, bucket, n):
+    resp = context.s3.list_multipart_uploads(Bucket=bucket)
+    uploads = resp.get("Uploads", [])
+    context._listed_uploads = uploads
+    assert len(uploads) == n, f"expected {n} uploads, got {len(uploads)}"
+
+
+@then('the upload keys include "{key1}" and "{key2}"')
+def step_upload_keys_include(context, key1, key2):
+    keys = sorted(u["Key"] for u in context._listed_uploads)
+    assert key1 in keys, f"{key1} not in {keys}"
+    assert key2 in keys, f"{key2} not in {keys}"
+    for u in context._listed_uploads:
+        assert "UploadId" in u, "missing UploadId"
+        assert "Initiated" in u, "missing Initiated"
+
+
+@then('listing multipart uploads in "{bucket}" with prefix "{prefix}" returns {n:d} upload')
+def step_list_uploads_prefix(context, bucket, prefix, n):
+    resp = context.s3.list_multipart_uploads(Bucket=bucket, Prefix=prefix)
+    uploads = resp.get("Uploads", [])
+    context._listed_uploads = uploads
+    assert len(uploads) == n, f"expected {n} uploads, got {len(uploads)}"
+
+
+@then('the upload key is "{key}"')
+def step_upload_key_is(context, key):
+    assert len(context._listed_uploads) >= 1
+    assert context._listed_uploads[0]["Key"] == key


### PR DESCRIPTION
Adds `GET /<bucket>?uploads` to list in-progress multipart uploads, used by SDK cleanup routines and `aws s3api list-multipart-uploads`.

## Implementation & Notes
* New `UploadSummary` type and `list_multipart_uploads(bucket, prefix)` method on the `Store` trait
* MemoryStore filters the uploads map by bucket and optional prefix; FsStore scans the `uploads/` directory reading each `meta.json`
* `InFlightUpload` (memory) and `UploadMeta` (fs) gain an `initiated` timestamp set at upload creation
* The existing `GET /:bucket` handler dispatches on `?uploads` query param before falling through to `list_objects`
* Returns `ListMultipartUploadsResult` XML with `Bucket`, `Prefix`, and `Upload` entries containing `Key`, `UploadId`, `Initiated`

## How to Test
```bash
cargo test --workspace
cd tests/integration && behave features/list_uploads.feature
```

## Suggested Commit Message
```
S3-17 Add ListMultipartUploads (GET /<bucket>?uploads) (#PR)

SDK cleanup routines and aws s3api list-multipart-uploads
need to enumerate in-progress uploads. This adds a new
list_multipart_uploads method to the Store trait with
implementations for both MemoryStore and FsStore.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)