### PR TITLE
S3-19 Add object tagging (PUT/GET/DELETE ?tagging)

### DIFF
--- a/crates/awrust-s3-domain/src/fs_store.rs
+++ b/crates/awrust-s3-domain/src/fs_store.rs
@@ -21,6 +21,8 @@ struct MetaFile {
     metadata: HashMap<String, String>,
     last_modified: u64,
     size: u64,
+    #[serde(default)]
+    tags: HashMap<String, String>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -101,6 +103,11 @@ impl FsStore {
             key: key.to_string(),
         })
     }
+
+    fn write_meta(&self, bucket: &str, key: &str, meta: &MetaFile) {
+        let meta_json = serde_json::to_vec(meta).expect("serialize meta");
+        fs::write(self.meta_path(bucket, key), &meta_json).expect("write meta");
+    }
 }
 
 fn now_secs() -> u64 {
@@ -174,10 +181,10 @@ impl Store for FsStore {
             metadata: input.metadata,
             last_modified: now_secs(),
             size,
+            tags: HashMap::new(),
         };
 
-        let meta_json = serde_json::to_vec(&meta).expect("serialize meta");
-        fs::write(self.meta_path(bucket, key), &meta_json).expect("write meta");
+        self.write_meta(bucket, key, &meta);
 
         Ok(())
     }
@@ -370,9 +377,9 @@ impl Store for FsStore {
             metadata: upload_meta.metadata,
             last_modified: now_secs(),
             size,
+            tags: HashMap::new(),
         };
-        let meta_json = serde_json::to_vec(&meta).expect("serialize meta");
-        fs::write(self.meta_path(bucket, &upload_meta.key), &meta_json).expect("write meta");
+        self.write_meta(bucket, &upload_meta.key, &meta);
 
         fs::remove_dir_all(&upload_dir).ok();
 
@@ -421,6 +428,33 @@ impl Store for FsStore {
             .collect();
         summaries.sort_by(|a, b| a.key.cmp(&b.key));
         Ok(summaries)
+    }
+
+    fn put_object_tagging(
+        &self,
+        bucket: &str,
+        key: &str,
+        tags: HashMap<String, String>,
+    ) -> Result<()> {
+        self.require_bucket(bucket)?;
+        let mut meta = self.read_meta(bucket, key)?;
+        meta.tags = tags;
+        self.write_meta(bucket, key, &meta);
+        Ok(())
+    }
+
+    fn get_object_tagging(&self, bucket: &str, key: &str) -> Result<HashMap<String, String>> {
+        self.require_bucket(bucket)?;
+        let meta = self.read_meta(bucket, key)?;
+        Ok(meta.tags)
+    }
+
+    fn delete_object_tagging(&self, bucket: &str, key: &str) -> Result<()> {
+        self.require_bucket(bucket)?;
+        let mut meta = self.read_meta(bucket, key)?;
+        meta.tags.clear();
+        self.write_meta(bucket, key, &meta);
+        Ok(())
     }
 }
 
@@ -593,6 +627,92 @@ mod tests {
         assert_eq!(copied.bytes, b"payload");
         assert_eq!(copied.meta.content_type, "text/plain");
         assert_eq!(copied.meta.metadata.get("tag").unwrap(), "v1");
+    }
+
+    #[test]
+    fn put_and_get_tagging() {
+        let (_tmp, store) = setup();
+        store.create_bucket("b").unwrap();
+        put(&store, "b", "k", b"data");
+
+        let tags = HashMap::from([
+            ("env".to_string(), "prod".to_string()),
+            ("team".to_string(), "data".to_string()),
+        ]);
+        store.put_object_tagging("b", "k", tags.clone()).unwrap();
+
+        let got = store.get_object_tagging("b", "k").unwrap();
+        assert_eq!(got, tags);
+    }
+
+    #[test]
+    fn get_tagging_empty_by_default() {
+        let (_tmp, store) = setup();
+        store.create_bucket("b").unwrap();
+        put(&store, "b", "k", b"data");
+
+        let tags = store.get_object_tagging("b", "k").unwrap();
+        assert!(tags.is_empty());
+    }
+
+    #[test]
+    fn delete_tagging() {
+        let (_tmp, store) = setup();
+        store.create_bucket("b").unwrap();
+        put(&store, "b", "k", b"data");
+
+        store
+            .put_object_tagging(
+                "b",
+                "k",
+                HashMap::from([("env".to_string(), "prod".to_string())]),
+            )
+            .unwrap();
+        store.delete_object_tagging("b", "k").unwrap();
+
+        let tags = store.get_object_tagging("b", "k").unwrap();
+        assert!(tags.is_empty());
+    }
+
+    #[test]
+    fn put_object_clears_tags() {
+        let (_tmp, store) = setup();
+        store.create_bucket("b").unwrap();
+        put(&store, "b", "k", b"v1");
+
+        store
+            .put_object_tagging(
+                "b",
+                "k",
+                HashMap::from([("env".to_string(), "prod".to_string())]),
+            )
+            .unwrap();
+
+        put(&store, "b", "k", b"v2");
+
+        let tags = store.get_object_tagging("b", "k").unwrap();
+        assert!(tags.is_empty());
+    }
+
+    #[test]
+    fn tagging_on_missing_object() {
+        let (_tmp, store) = setup();
+        store.create_bucket("b").unwrap();
+
+        assert!(matches!(
+            store.get_object_tagging("b", "nope"),
+            Err(StoreError::ObjectNotFound { .. })
+        ));
+    }
+
+    #[test]
+    fn tagging_on_missing_bucket() {
+        let (_tmp, store) = setup();
+
+        assert!(matches!(
+            store.get_object_tagging("nope", "k"),
+            Err(StoreError::BucketNotFound(_))
+        ));
     }
 
     #[test]

--- a/crates/awrust-s3-domain/src/lib.rs
+++ b/crates/awrust-s3-domain/src/lib.rs
@@ -135,6 +135,15 @@ pub trait Store: Send + Sync {
         bucket: &str,
         prefix: Option<&str>,
     ) -> Result<Vec<UploadSummary>>;
+
+    fn put_object_tagging(
+        &self,
+        bucket: &str,
+        key: &str,
+        tags: HashMap<String, String>,
+    ) -> Result<()>;
+    fn get_object_tagging(&self, bucket: &str, key: &str) -> Result<HashMap<String, String>>;
+    fn delete_object_tagging(&self, bucket: &str, key: &str) -> Result<()>;
 }
 
 #[derive(Debug, Default)]
@@ -165,6 +174,7 @@ struct ObjectRecord {
     content_type: String,
     metadata: HashMap<String, String>,
     last_modified: u64,
+    tags: HashMap<String, String>,
 }
 
 #[derive(Debug)]
@@ -329,6 +339,7 @@ impl Store for MemoryStore {
                 content_type: input.content_type,
                 metadata: input.metadata,
                 last_modified: now_secs(),
+                tags: HashMap::new(),
             },
         );
         Ok(())
@@ -528,6 +539,7 @@ impl Store for MemoryStore {
                 content_type: upload.content_type,
                 metadata: upload.metadata,
                 last_modified: now_secs(),
+                tags: HashMap::new(),
             },
         );
 
@@ -567,6 +579,60 @@ impl Store for MemoryStore {
             .collect();
         summaries.sort_by(|a, b| a.key.cmp(&b.key));
         Ok(summaries)
+    }
+
+    fn put_object_tagging(
+        &self,
+        bucket: &str,
+        key: &str,
+        tags: HashMap<String, String>,
+    ) -> Result<()> {
+        let mut buckets = self.buckets.write().expect("lock poisoned");
+        let bucket_state = buckets
+            .get_mut(bucket)
+            .ok_or_else(|| StoreError::BucketNotFound(bucket.to_string()))?;
+        let record =
+            bucket_state
+                .objects
+                .get_mut(key)
+                .ok_or_else(|| StoreError::ObjectNotFound {
+                    bucket: bucket.to_string(),
+                    key: key.to_string(),
+                })?;
+        record.tags = tags;
+        Ok(())
+    }
+
+    fn get_object_tagging(&self, bucket: &str, key: &str) -> Result<HashMap<String, String>> {
+        let buckets = self.buckets.read().expect("lock poisoned");
+        let bucket_state = buckets
+            .get(bucket)
+            .ok_or_else(|| StoreError::BucketNotFound(bucket.to_string()))?;
+        let record = bucket_state
+            .objects
+            .get(key)
+            .ok_or_else(|| StoreError::ObjectNotFound {
+                bucket: bucket.to_string(),
+                key: key.to_string(),
+            })?;
+        Ok(record.tags.clone())
+    }
+
+    fn delete_object_tagging(&self, bucket: &str, key: &str) -> Result<()> {
+        let mut buckets = self.buckets.write().expect("lock poisoned");
+        let bucket_state = buckets
+            .get_mut(bucket)
+            .ok_or_else(|| StoreError::BucketNotFound(bucket.to_string()))?;
+        let record =
+            bucket_state
+                .objects
+                .get_mut(key)
+                .ok_or_else(|| StoreError::ObjectNotFound {
+                    bucket: bucket.to_string(),
+                    key: key.to_string(),
+                })?;
+        record.tags.clear();
+        Ok(())
     }
 }
 

--- a/crates/awrust-s3-domain/tests/memory_store.rs
+++ b/crates/awrust-s3-domain/tests/memory_store.rs
@@ -1,4 +1,4 @@
-use awrust_s3_domain::{ListObjectsParams, MemoryStore, PutObject, Store};
+use awrust_s3_domain::{ListObjectsParams, MemoryStore, PutObject, Store, StoreError};
 use std::collections::HashMap;
 
 fn put(store: &MemoryStore, bucket: &str, key: &str, bytes: &[u8]) {
@@ -282,4 +282,100 @@ fn delimiter_without_matches_returns_all_as_contents() {
     let keys: Vec<&str> = page.objects.iter().map(|o| o.key.as_str()).collect();
     assert_eq!(keys, vec!["a.txt", "b.txt"]);
     assert!(page.common_prefixes.is_empty());
+}
+
+#[test]
+fn put_and_get_tagging() {
+    let store = MemoryStore::new();
+    store.create_bucket("bucket").unwrap();
+    put(&store, "bucket", "key", b"data");
+
+    let tags = HashMap::from([
+        ("env".to_string(), "prod".to_string()),
+        ("team".to_string(), "data".to_string()),
+    ]);
+    store
+        .put_object_tagging("bucket", "key", tags.clone())
+        .unwrap();
+
+    let got = store.get_object_tagging("bucket", "key").unwrap();
+    assert_eq!(got, tags);
+}
+
+#[test]
+fn get_tagging_empty_by_default() {
+    let store = MemoryStore::new();
+    store.create_bucket("bucket").unwrap();
+    put(&store, "bucket", "key", b"data");
+
+    let tags = store.get_object_tagging("bucket", "key").unwrap();
+    assert!(tags.is_empty());
+}
+
+#[test]
+fn delete_tagging() {
+    let store = MemoryStore::new();
+    store.create_bucket("bucket").unwrap();
+    put(&store, "bucket", "key", b"data");
+
+    store
+        .put_object_tagging(
+            "bucket",
+            "key",
+            HashMap::from([("env".to_string(), "prod".to_string())]),
+        )
+        .unwrap();
+    store.delete_object_tagging("bucket", "key").unwrap();
+
+    let tags = store.get_object_tagging("bucket", "key").unwrap();
+    assert!(tags.is_empty());
+}
+
+#[test]
+fn put_object_clears_tags() {
+    let store = MemoryStore::new();
+    store.create_bucket("bucket").unwrap();
+    put(&store, "bucket", "key", b"v1");
+
+    store
+        .put_object_tagging(
+            "bucket",
+            "key",
+            HashMap::from([("env".to_string(), "prod".to_string())]),
+        )
+        .unwrap();
+
+    put(&store, "bucket", "key", b"v2");
+
+    let tags = store.get_object_tagging("bucket", "key").unwrap();
+    assert!(tags.is_empty());
+}
+
+#[test]
+fn tagging_on_missing_object() {
+    let store = MemoryStore::new();
+    store.create_bucket("bucket").unwrap();
+
+    assert!(matches!(
+        store.get_object_tagging("bucket", "nope"),
+        Err(StoreError::ObjectNotFound { .. })
+    ));
+    assert!(matches!(
+        store.put_object_tagging("bucket", "nope", HashMap::new()),
+        Err(StoreError::ObjectNotFound { .. })
+    ));
+    assert!(matches!(
+        store.delete_object_tagging("bucket", "nope"),
+        Err(StoreError::ObjectNotFound { .. })
+    ));
+}
+
+#[test]
+fn tagging_on_missing_bucket() {
+    let store = MemoryStore::new();
+
+    assert!(matches!(
+        store.get_object_tagging("nope", "key"),
+        Err(StoreError::BucketNotFound(_))
+    ));
 }

--- a/crates/awrust-s3-server/src/handlers.rs
+++ b/crates/awrust-s3-server/src/handlers.rs
@@ -13,7 +13,7 @@ use crate::xml::{
     BucketEntry, BucketList, CommonPrefix, CompleteMultipartUploadResult, CopyObjectResult,
     DeleteErrorEntry, DeleteResult, DeletedEntry, InitiateMultipartUploadResult,
     ListAllMyBucketsResult, ListBucketResult, ListMultipartUploadsResult, LocationConstraint,
-    ObjectEntry, UploadEntry, XmlResponse,
+    ObjectEntry, Tagging, UploadEntry, XmlResponse,
 };
 
 type S3Result<T> = Result<T, S3Error>;
@@ -214,6 +214,7 @@ pub struct ObjectQueryParams {
     #[serde(rename = "partNumber")]
     pub part_number: Option<u32>,
     pub uploads: Option<String>,
+    pub tagging: Option<String>,
 }
 
 pub async fn put_object_or_part(
@@ -223,6 +224,18 @@ pub async fn put_object_or_part(
     headers: HeaderMap,
     body: Bytes,
 ) -> S3Result<Response> {
+    if params.tagging.is_some() {
+        let tagging: Tagging =
+            quick_xml::de::from_str(&String::from_utf8_lossy(&body)).map_err(|_| {
+                awrust_s3_domain::StoreError::ObjectNotFound {
+                    bucket: bucket.clone(),
+                    key: key.clone(),
+                }
+            })?;
+        store.put_object_tagging(&bucket, &key, tagging.into_map())?;
+        return Ok(StatusCode::OK.into_response());
+    }
+
     if let Some(copy_source) = headers
         .get("x-amz-copy-source")
         .and_then(|v| v.to_str().ok())
@@ -305,8 +318,14 @@ pub async fn post_object(
 pub async fn get_object(
     State(store): State<Arc<dyn Store>>,
     Path((bucket, key)): Path<(String, String)>,
+    Query(params): Query<ObjectQueryParams>,
     headers: HeaderMap,
 ) -> S3Result<Response> {
+    if params.tagging.is_some() {
+        let tags = store.get_object_tagging(&bucket, &key)?;
+        return Ok(XmlResponse(Tagging::from_map(tags)).into_response());
+    }
+
     let obj = store.get_object(&bucket, &key)?;
     let total_size = obj.bytes.len();
 
@@ -358,6 +377,11 @@ pub async fn delete_object_or_abort(
     Path((bucket, key)): Path<(String, String)>,
     Query(params): Query<ObjectQueryParams>,
 ) -> S3Result<StatusCode> {
+    if params.tagging.is_some() {
+        store.delete_object_tagging(&bucket, &key)?;
+        return Ok(StatusCode::NO_CONTENT);
+    }
+
     if let Some(upload_id) = &params.upload_id {
         store.abort_multipart(&bucket, &key, upload_id)?;
         return Ok(StatusCode::NO_CONTENT);

--- a/crates/awrust-s3-server/src/xml.rs
+++ b/crates/awrust-s3-server/src/xml.rs
@@ -188,6 +188,48 @@ pub struct LocationConstraint {
     pub region: String,
 }
 
+#[derive(Serialize, Deserialize)]
+#[serde(rename = "Tagging")]
+pub struct Tagging {
+    #[serde(rename = "TagSet")]
+    pub tag_set: TagSet,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct TagSet {
+    #[serde(rename = "Tag", default)]
+    pub tags: Vec<Tag>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Tag {
+    #[serde(rename = "Key")]
+    pub key: String,
+    #[serde(rename = "Value")]
+    pub value: String,
+}
+
+impl Tagging {
+    pub fn from_map(map: std::collections::HashMap<String, String>) -> Self {
+        let mut tags: Vec<Tag> = map
+            .into_iter()
+            .map(|(key, value)| Tag { key, value })
+            .collect();
+        tags.sort_by(|a, b| a.key.cmp(&b.key));
+        Self {
+            tag_set: TagSet { tags },
+        }
+    }
+
+    pub fn into_map(self) -> std::collections::HashMap<String, String> {
+        self.tag_set
+            .tags
+            .into_iter()
+            .map(|t| (t.key, t.value))
+            .collect()
+    }
+}
+
 pub struct XmlResponse<T: Serialize>(pub T);
 
 impl<T: Serialize> IntoResponse for XmlResponse<T> {

--- a/tests/integration/features/tagging.feature
+++ b/tests/integration/features/tagging.feature
@@ -1,0 +1,30 @@
+Feature: Object tagging
+
+  Background:
+    Given bucket "tag-bucket" exists
+
+  Scenario: Set and get tags
+    Given object "tag-bucket/tagged.txt" contains "data"
+    When I set tags on "tag-bucket/tagged.txt" with "env=prod,team=data"
+    Then object "tag-bucket/tagged.txt" should have tag "env" with value "prod"
+    And object "tag-bucket/tagged.txt" should have tag "team" with value "data"
+
+  Scenario: Get tags returns empty when none set
+    Given object "tag-bucket/no-tags.txt" contains "data"
+    Then object "tag-bucket/no-tags.txt" should have no tags
+
+  Scenario: Delete tags
+    Given object "tag-bucket/del-tags.txt" contains "data"
+    When I set tags on "tag-bucket/del-tags.txt" with "env=prod"
+    And I delete tags on "tag-bucket/del-tags.txt"
+    Then object "tag-bucket/del-tags.txt" should have no tags
+
+  Scenario: Put object clears existing tags
+    Given object "tag-bucket/overwrite.txt" contains "v1"
+    When I set tags on "tag-bucket/overwrite.txt" with "env=prod"
+    And I put object "tag-bucket/overwrite.txt" with content "v2"
+    Then object "tag-bucket/overwrite.txt" should have no tags
+
+  Scenario: Tagging a non-existent object fails
+    When I try to get tags on "tag-bucket/nope.txt"
+    Then the tagging operation should fail

--- a/tests/integration/steps/tagging_steps.py
+++ b/tests/integration/steps/tagging_steps.py
@@ -1,0 +1,61 @@
+from behave import when, then
+from botocore.exceptions import ClientError
+
+
+def _split(path):
+    bucket, key = path.split("/", 1)
+    return bucket, key
+
+
+@when('I set tags on "{path}" with "{tags_str}"')
+def step_put_tagging(context, path, tags_str):
+    bucket, key = _split(path)
+    tag_set = []
+    for pair in tags_str.split(","):
+        k, v = pair.split("=")
+        tag_set.append({"Key": k, "Value": v})
+    context.s3.put_object_tagging(
+        Bucket=bucket, Key=key, Tagging={"TagSet": tag_set}
+    )
+
+
+@when('I delete tags on "{path}"')
+def step_delete_tagging(context, path):
+    bucket, key = _split(path)
+    context.s3.delete_object_tagging(Bucket=bucket, Key=key)
+
+
+@when('I try to get tags on "{path}"')
+def step_try_get_tagging(context, path):
+    bucket, key = _split(path)
+    try:
+        context.s3.get_object_tagging(Bucket=bucket, Key=key)
+        context.last_tagging_error = None
+    except ClientError as e:
+        context.last_tagging_error = e
+
+
+@then('object "{path}" should have tag "{tag_key}" with value "{tag_value}"')
+def step_assert_tag(context, path, tag_key, tag_value):
+    bucket, key = _split(path)
+    resp = context.s3.get_object_tagging(Bucket=bucket, Key=key)
+    tags = {t["Key"]: t["Value"] for t in resp.get("TagSet", [])}
+    actual = tags.get(tag_key)
+    assert actual == tag_value, (
+        f"expected tag {tag_key}={tag_value}, got {actual} (all: {tags})"
+    )
+
+
+@then('object "{path}" should have no tags')
+def step_assert_no_tags(context, path):
+    bucket, key = _split(path)
+    resp = context.s3.get_object_tagging(Bucket=bucket, Key=key)
+    tag_set = resp.get("TagSet", [])
+    assert len(tag_set) == 0, f"expected no tags, got {tag_set}"
+
+
+@then("the tagging operation should fail")
+def step_assert_tagging_failed(context):
+    assert context.last_tagging_error is not None, (
+        "expected an error but tagging operation succeeded"
+    )


### PR DESCRIPTION
S3-compatible object tagging via `?tagging` query parameter on `/:bucket/*key`.

## Implementation & Notes
* Three new `Store` trait methods: `put_object_tagging`, `get_object_tagging`, `delete_object_tagging` — implemented for both MemoryStore and FsStore.
* Tags stored as `HashMap<String, String>` on `ObjectRecord` (memory) and `MetaFile` (fs). `put_object` and `complete_multipart` reset tags to empty, so tags do not survive object overwrites.
* FsStore uses `#[serde(default)]` on the `tags` field for backward compatibility with existing meta JSON files.
* Extracted `write_meta` helper in FsStore to eliminate duplicated serialize-and-write across three call sites.
* Server dispatches via early returns in `put_object_or_part`, `get_object`, and `delete_object_or_abort` when `?tagging` is present.
* `Tagging`/`TagSet`/`Tag` XML types derive both Serialize and Deserialize since request and response shapes are identical.

## How to Test
```bash
cargo fmt --all --check
cargo clippy -- -D warnings
cargo test --workspace
cd tests/integration && behave
STORE=fs behave
```

## Suggested Commit Message
```
S3-19 Add object tagging (PUT/GET/DELETE ?tagging) (#PR)

Implement S3-compatible object tagging with three new
operations dispatched via the ?tagging query parameter.
Tags stored per-object, cleared on overwrite, covered by
12 unit tests and 5 BDD scenarios.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)