### PR TITLE
S3-21 Add ListObjectVersions stub

### DIFF
--- a/crates/awrust-s3-server/src/handlers.rs
+++ b/crates/awrust-s3-server/src/handlers.rs
@@ -12,8 +12,8 @@ use crate::error::S3Error;
 use crate::xml::{
     BucketEntry, BucketList, CommonPrefix, CompleteMultipartUploadResult, CopyObjectResult,
     DeleteErrorEntry, DeleteResult, DeletedEntry, InitiateMultipartUploadResult,
-    ListAllMyBucketsResult, ListBucketResult, ListMultipartUploadsResult, LocationConstraint,
-    ObjectEntry, Tagging, UploadEntry, XmlResponse,
+    ListAllMyBucketsResult, ListBucketResult, ListMultipartUploadsResult, ListVersionsResult,
+    LocationConstraint, ObjectEntry, Tagging, UploadEntry, VersionEntry, XmlResponse,
 };
 
 type S3Result<T> = Result<T, S3Error>;
@@ -118,6 +118,7 @@ pub struct ListParams {
     #[serde(rename = "continuation-token")]
     pub continuation_token: Option<String>,
     pub uploads: Option<String>,
+    pub versions: Option<String>,
 }
 
 pub async fn get_bucket(
@@ -167,6 +168,10 @@ pub async fn list_objects(
         return Ok(XmlResponse(result).into_response());
     }
 
+    if params.versions.is_some() {
+        return list_object_versions(store, &bucket, &params).await;
+    }
+
     let max_keys = params.max_keys.unwrap_or(1000);
     let page = store.list_objects(
         &bucket,
@@ -201,6 +206,47 @@ pub async fn list_objects(
             .common_prefixes
             .into_iter()
             .map(|p| CommonPrefix { prefix: p })
+            .collect(),
+    };
+
+    Ok(XmlResponse(result).into_response())
+}
+
+async fn list_object_versions(
+    store: Arc<dyn Store>,
+    bucket: &str,
+    params: &ListParams,
+) -> S3Result<Response> {
+    let max_keys = params.max_keys.unwrap_or(1000);
+    let page = store.list_objects(
+        bucket,
+        &ListObjectsParams {
+            prefix: params.prefix.clone(),
+            delimiter: None,
+            continuation_token: None,
+            max_keys,
+        },
+    )?;
+
+    let result = ListVersionsResult {
+        name: bucket.to_owned(),
+        prefix: params.prefix.clone().unwrap_or_default(),
+        key_marker: String::new(),
+        version_id_marker: String::new(),
+        max_keys,
+        is_truncated: page.is_truncated,
+        versions: page
+            .objects
+            .into_iter()
+            .map(|o| VersionEntry {
+                key: o.key,
+                version_id: "null".to_owned(),
+                is_latest: true,
+                last_modified: format_iso8601(o.last_modified),
+                etag: o.etag,
+                size: o.size,
+                storage_class: "STANDARD".to_owned(),
+            })
             .collect(),
     };
 

--- a/crates/awrust-s3-server/src/xml.rs
+++ b/crates/awrust-s3-server/src/xml.rs
@@ -126,6 +126,43 @@ pub struct UploadEntry {
     pub initiated: String,
 }
 
+#[derive(Serialize)]
+#[serde(rename = "ListVersionsResult")]
+pub struct ListVersionsResult {
+    #[serde(rename = "Name")]
+    pub name: String,
+    #[serde(rename = "Prefix")]
+    pub prefix: String,
+    #[serde(rename = "KeyMarker")]
+    pub key_marker: String,
+    #[serde(rename = "VersionIdMarker")]
+    pub version_id_marker: String,
+    #[serde(rename = "MaxKeys")]
+    pub max_keys: usize,
+    #[serde(rename = "IsTruncated")]
+    pub is_truncated: bool,
+    #[serde(rename = "Version", default)]
+    pub versions: Vec<VersionEntry>,
+}
+
+#[derive(Serialize)]
+pub struct VersionEntry {
+    #[serde(rename = "Key")]
+    pub key: String,
+    #[serde(rename = "VersionId")]
+    pub version_id: String,
+    #[serde(rename = "IsLatest")]
+    pub is_latest: bool,
+    #[serde(rename = "LastModified")]
+    pub last_modified: String,
+    #[serde(rename = "ETag")]
+    pub etag: String,
+    #[serde(rename = "Size")]
+    pub size: u64,
+    #[serde(rename = "StorageClass")]
+    pub storage_class: String,
+}
+
 #[derive(Deserialize)]
 #[serde(rename = "CompleteMultipartUpload")]
 pub struct CompleteMultipartUploadRequest {

--- a/tests/integration/features/versions.feature
+++ b/tests/integration/features/versions.feature
@@ -1,0 +1,25 @@
+Feature: ListObjectVersions stub
+
+  Background:
+    Given bucket "ver-bucket" exists
+
+  Scenario: List versions returns objects with VersionId null
+    Given object "ver-bucket/a.txt" contains "alpha"
+    And object "ver-bucket/b.txt" contains "beta"
+    When I list object versions in "ver-bucket"
+    Then the version list should contain keys "a.txt,b.txt"
+    And every version id should be "null"
+    And every version should be latest
+
+  Scenario: List versions on empty bucket returns empty list
+    Given bucket "ver-empty" exists
+    When I list object versions in "ver-empty"
+    Then the version list should be empty
+
+  Scenario: List versions with prefix filter
+    Given object "ver-bucket/x/1.txt" contains "one"
+    And object "ver-bucket/x/2.txt" contains "two"
+    And object "ver-bucket/y/1.txt" contains "three"
+    And version list prefix is "x/"
+    When I list object versions in "ver-bucket"
+    Then the version list should contain keys "x/1.txt,x/2.txt"

--- a/tests/integration/steps/version_steps.py
+++ b/tests/integration/steps/version_steps.py
@@ -1,0 +1,49 @@
+from behave import given, when, then
+
+
+@given('version list prefix is "{prefix}"')
+def step_set_version_prefix(context, prefix):
+    context.version_prefix = prefix
+
+
+@when('I list object versions in "{bucket}"')
+def step_list_versions(context, bucket):
+    kwargs = {"Bucket": bucket}
+    prefix = getattr(context, "version_prefix", None)
+    if prefix:
+        kwargs["Prefix"] = prefix
+    resp = context.s3.list_object_versions(**kwargs)
+    context.versions = resp.get("Versions", [])
+    context.version_prefix = None
+
+
+@then('the version list should contain keys "{expected}"')
+def step_assert_version_keys(context, expected):
+    expected_keys = expected.split(",")
+    actual_keys = [v["Key"] for v in context.versions]
+    assert actual_keys == expected_keys, (
+        f"expected {expected_keys}, got {actual_keys}"
+    )
+
+
+@then("the version list should be empty")
+def step_assert_versions_empty(context):
+    assert len(context.versions) == 0, (
+        f"expected empty, got {context.versions}"
+    )
+
+
+@then('every version id should be "{expected}"')
+def step_assert_version_ids(context, expected):
+    for v in context.versions:
+        assert v["VersionId"] == expected, (
+            f"expected VersionId={expected}, got {v['VersionId']}"
+        )
+
+
+@then("every version should be latest")
+def step_assert_all_latest(context):
+    for v in context.versions:
+        assert v["IsLatest"] is True, (
+            f"expected IsLatest=True for {v['Key']}"
+        )


### PR DESCRIPTION
Return a valid `ListVersionsResult` XML for `GET /<bucket>?versions` so SDKs that call this during setup/cleanup no longer error.

## Implementation & Notes
* Detects `?versions` query param in the existing `list_objects` handler and dispatches to `list_object_versions()`
* Reuses `store.list_objects()` — no domain/store changes needed
* Returns each object as a single version with `VersionId="null"`, `IsLatest=true`, `StorageClass="STANDARD"`
* Adds `ListVersionsResult` and `VersionEntry` XML types in `xml.rs`

## How to Test
```bash
cargo test --workspace
cd tests/integration && behave features/versions.feature
STORE=fs behave features/versions.feature
```

## Suggested Commit Message
```
S3-21 Add ListObjectVersions stub (#PR)

Some S3 SDKs call GET /<bucket>?versions during setup or
cleanup and error without a response. This adds a stub that
returns current objects as single versions with
VersionId="null", indicating versioning is not enabled.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
```

Closes #21