### PR TITLE
S3-20 Add CORS preflight support for browser-based S3 access

### DIFF
--- a/crates/awrust-s3-server/Cargo.toml
+++ b/crates/awrust-s3-server/Cargo.toml
@@ -12,7 +12,7 @@ quick-xml = { version = "0.37", features = ["serialize", "serde"] }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tower = "0.5"
-tower-http = { version = "0.5", features = ["trace"] }
+tower-http = { version = "0.5", features = ["trace", "cors"] }
 tracing = "0.1"
 uuid = { version = "1", features = ["v4"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }

--- a/crates/awrust-s3-server/src/main.rs
+++ b/crates/awrust-s3-server/src/main.rs
@@ -13,6 +13,7 @@ use axum::{Json, Router, ServiceExt, extract::Request};
 use serde::Serialize;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use tower_http::cors::CorsLayer;
 use tower_http::trace::{DefaultMakeSpan, DefaultOnResponse, TraceLayer};
 use tracing::{Level, info};
 use tracing_subscriber::{EnvFilter, fmt};
@@ -80,7 +81,8 @@ async fn main() {
             TraceLayer::new_for_http()
                 .make_span_with(DefaultMakeSpan::new().level(Level::INFO))
                 .on_response(DefaultOnResponse::new().level(Level::INFO)),
-        );
+        )
+        .layer(CorsLayer::very_permissive());
 
     let app = vhost::VhostService::new(app, base_domain);
 

--- a/tests/integration/features/cors.feature
+++ b/tests/integration/features/cors.feature
@@ -1,0 +1,14 @@
+Feature: CORS preflight
+
+  Scenario: OPTIONS request returns CORS headers
+    When I send an OPTIONS preflight for "PUT" on "/test-bucket/test-key"
+    Then the CORS response status should be 200
+    And the CORS response should include header "access-control-allow-origin"
+    And the CORS response should include header "access-control-allow-methods"
+    And the CORS response should include header "access-control-allow-headers"
+    And the CORS response body should be empty
+
+  Scenario: Normal GET includes CORS origin header
+    When I send a GET request to "/health"
+    Then the CORS response status should be 200
+    And the CORS response should include header "access-control-allow-origin"

--- a/tests/integration/steps/cors_steps.py
+++ b/tests/integration/steps/cors_steps.py
@@ -1,0 +1,47 @@
+import urllib.request
+
+from behave import when, then
+
+
+@when('I send an OPTIONS preflight for "{method}" on "{path}"')
+def step_options_preflight(context, method, path):
+    url = f"{context.base_url}{path}"
+    req = urllib.request.Request(url, method="OPTIONS")
+    req.add_header("Origin", "http://localhost:3000")
+    req.add_header("Access-Control-Request-Method", method)
+    req.add_header("Access-Control-Request-Headers", "content-type")
+    context.cors_response = urllib.request.urlopen(req)
+
+
+@when('I send a GET request to "{path}"')
+def step_get_request(context, path):
+    url = f"{context.base_url}{path}"
+    req = urllib.request.Request(url, method="GET")
+    req.add_header("Origin", "http://localhost:3000")
+    context.cors_response = urllib.request.urlopen(req)
+
+
+@then("the CORS response status should be {code:d}")
+def step_check_status(context, code):
+    assert context.cors_response.status == code, (
+        f"expected {code}, got {context.cors_response.status}"
+    )
+
+
+@then('the CORS response should include header "{name}" with value "{value}"')
+def step_check_header_value(context, name, value):
+    actual = context.cors_response.getheader(name)
+    assert actual is not None, f"header '{name}' not found"
+    assert actual == value, f"expected '{value}', got '{actual}'"
+
+
+@then('the CORS response should include header "{name}"')
+def step_check_header_present(context, name):
+    actual = context.cors_response.getheader(name)
+    assert actual is not None, f"header '{name}' not found"
+
+
+@then("the CORS response body should be empty")
+def step_check_empty_body(context):
+    body = context.cors_response.read()
+    assert len(body) == 0, f"expected empty body, got {len(body)} bytes"


### PR DESCRIPTION
Enable permissive CORS so browser-based S3 clients can make cross-origin requests against the emulator.

## Implementation & Notes
* Enabled the `cors` feature on `tower-http` (already a dependency for `trace`) — no new crate, no ADR needed.
* Added `CorsLayer::very_permissive()` as the outermost middleware layer so it intercepts OPTIONS preflight requests before they reach routing.
* `very_permissive()` mirrors the request origin back (rather than `*`), allows all methods and headers — appropriate for a local-dev emulator.

## How to Test
```bash
# BDD tests
cd tests/integration && behave features/cors.feature

# Manual smoke test
curl -i -X OPTIONS http://localhost:4566/my-bucket/my-key \
  -H "Origin: http://localhost:3000" \
  -H "Access-Control-Request-Method: PUT" \
  -H "Access-Control-Request-Headers: content-type"
```

## Suggested Commit Message
```
S3-20 Add CORS preflight support for browser-based S3 access (#PR)

Browser-based S3 clients send OPTIONS preflight requests that
the server was not handling. Enable the cors feature on
tower-http (already a dependency) and add CorsLayer as the
outermost middleware layer so it intercepts OPTIONS before
routing. Uses very_permissive() to allow all origins, methods,
and headers — appropriate for a local-dev S3 emulator.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
```

Closes #20