### PR TITLE
S3-18 Add virtual-host style addressing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ docs/
 
 ## S3 compatibility
 
-- Path-style addressing only: `/<bucket>/<key>`
+- Path-style (`/<bucket>/<key>`) and virtual-host (`bucket.host/<key>`) addressing
 - No auth validation (accept all requests)
 - ETags: MD5 for single-part, composite MD5 for multipart
 - XML responses via quick-xml with serde
@@ -76,4 +76,5 @@ docs/
 | `AWRUST_S3_LISTEN_ADDR` | `0.0.0.0:4566` | Listen address |
 | `AWRUST_S3_STORE` | `memory` | `memory` or `fs` |
 | `AWRUST_S3_DATA_DIR` | `/data` | Data dir for fs backend |
+| `AWRUST_S3_BASE_DOMAIN` | `localhost` | Base domain for virtual-host addressing |
 | `AWRUST_LOG` | `info` | Log level |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,7 @@ dependencies = [
  "quick-xml",
  "serde",
  "tokio",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",

--- a/crates/awrust-s3-server/Cargo.toml
+++ b/crates/awrust-s3-server/Cargo.toml
@@ -11,6 +11,7 @@ md-5 = "0.10"
 quick-xml = { version = "0.37", features = ["serialize", "serde"] }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tower = "0.5"
 tower-http = { version = "0.5", features = ["trace"] }
 tracing = "0.1"
 uuid = { version = "1", features = ["v4"] }

--- a/crates/awrust-s3-server/src/main.rs
+++ b/crates/awrust-s3-server/src/main.rs
@@ -1,5 +1,6 @@
 mod error;
 mod handlers;
+mod vhost;
 mod xml;
 
 use awrust_s3_domain::{FsStore, MemoryStore, Store};
@@ -8,7 +9,7 @@ use axum::middleware::{self, Next};
 use axum::response::IntoResponse;
 use axum::response::Response;
 use axum::routing::{get, put};
-use axum::{Json, Router, extract::Request};
+use axum::{Json, Router, ServiceExt, extract::Request};
 use serde::Serialize;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -39,6 +40,11 @@ async fn main() {
             Arc::new(MemoryStore::new())
         }
     };
+
+    let base_domain: Arc<String> = Arc::new(
+        std::env::var("AWRUST_S3_BASE_DOMAIN").unwrap_or_else(|_| "localhost".to_string()),
+    );
+    info!(%base_domain, "virtual-host base domain");
 
     let app = Router::new()
         .route("/health", get(health))
@@ -76,6 +82,8 @@ async fn main() {
                 .on_response(DefaultOnResponse::new().level(Level::INFO)),
         );
 
+    let app = vhost::VhostService::new(app, base_domain);
+
     let addr: SocketAddr = std::env::var("AWRUST_S3_LISTEN_ADDR")
         .unwrap_or_else(|_| "0.0.0.0:4566".to_string())
         .parse()
@@ -86,7 +94,9 @@ async fn main() {
         .await
         .expect("bind listen addr");
 
-    axum::serve(listener, app).await.expect("server error");
+    axum::serve(listener, app.into_make_service())
+        .await
+        .expect("server error");
 }
 
 async fn request_id(req: Request, next: Next) -> Response {

--- a/crates/awrust-s3-server/src/vhost.rs
+++ b/crates/awrust-s3-server/src/vhost.rs
@@ -1,0 +1,143 @@
+use axum::extract::Request;
+use axum::http::Uri;
+use axum::response::Response;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use tower::Service;
+
+fn extract_bucket<'a>(host: &'a str, base_domain: &str) -> Option<&'a str> {
+    let host = host.split(':').next()?;
+    let prefix = host.strip_suffix(base_domain)?.strip_suffix('.')?;
+    if prefix.is_empty() {
+        return None;
+    }
+    Some(prefix)
+}
+
+#[derive(Clone)]
+pub struct VhostService<S> {
+    inner: S,
+    base_domain: Arc<String>,
+}
+
+impl<S> VhostService<S> {
+    pub fn new(inner: S, base_domain: Arc<String>) -> Self {
+        Self { inner, base_domain }
+    }
+}
+
+impl<S> Service<Request> for VhostService<S>
+where
+    S: Service<Request, Response = Response> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Response, S::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request) -> Self::Future {
+        let bucket = req
+            .headers()
+            .get("host")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|host| extract_bucket(host, &self.base_domain))
+            .map(str::to_owned);
+
+        let req = if let Some(bucket) = bucket {
+            let path = req.uri().path();
+            let query = req.uri().query().map(str::to_owned);
+            let suffix = path.strip_prefix('/').unwrap_or(path);
+            let new_path = if suffix.is_empty() {
+                format!("/{bucket}")
+            } else {
+                format!("/{bucket}/{suffix}")
+            };
+            let new_uri: Uri = match query {
+                Some(q) => format!("{new_path}?{q}"),
+                None => new_path,
+            }
+            .parse()
+            .expect("valid rewritten URI");
+
+            let (mut parts, body) = req.into_parts();
+            parts.uri = new_uri;
+            Request::from_parts(parts, body)
+        } else {
+            req
+        };
+
+        let fut = self.inner.call(req);
+        Box::pin(fut)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn subdomain_extracted() {
+        assert_eq!(
+            extract_bucket("mybucket.localhost", "localhost"),
+            Some("mybucket")
+        );
+    }
+
+    #[test]
+    fn subdomain_with_port() {
+        assert_eq!(
+            extract_bucket("mybucket.localhost:4566", "localhost"),
+            Some("mybucket")
+        );
+    }
+
+    #[test]
+    fn bare_host_returns_none() {
+        assert_eq!(extract_bucket("localhost", "localhost"), None);
+    }
+
+    #[test]
+    fn bare_host_with_port_returns_none() {
+        assert_eq!(extract_bucket("localhost:4566", "localhost"), None);
+    }
+
+    #[test]
+    fn deep_subdomain() {
+        assert_eq!(
+            extract_bucket("deep.sub.localhost", "localhost"),
+            Some("deep.sub")
+        );
+    }
+
+    #[test]
+    fn custom_base_domain() {
+        assert_eq!(
+            extract_bucket("mybucket.example.com", "example.com"),
+            Some("mybucket")
+        );
+    }
+
+    #[test]
+    fn custom_base_domain_with_port() {
+        assert_eq!(
+            extract_bucket("mybucket.example.com:9000", "example.com"),
+            Some("mybucket")
+        );
+    }
+
+    #[test]
+    fn unrelated_host_returns_none() {
+        assert_eq!(extract_bucket("other.com:4566", "localhost"), None);
+    }
+
+    #[test]
+    fn empty_host_returns_none() {
+        assert_eq!(extract_bucket("", "localhost"), None);
+    }
+}

--- a/tests/integration/environment.py
+++ b/tests/integration/environment.py
@@ -38,6 +38,7 @@ def _start_cargo(context, port, store):
     env = os.environ.copy()
     env["AWRUST_S3_LISTEN_ADDR"] = f"127.0.0.1:{port}"
     env["AWRUST_S3_STORE"] = store
+    env["AWRUST_S3_BASE_DOMAIN"] = "localhost"
     env["AWRUST_LOG"] = "warn"
 
     if store == "fs":
@@ -57,6 +58,7 @@ def _start_docker(context, port, store, image):
     docker_env = {
         "AWRUST_S3_LISTEN_ADDR": f"0.0.0.0:4566",
         "AWRUST_S3_STORE": store,
+        "AWRUST_S3_BASE_DOMAIN": "localhost",
         "AWRUST_LOG": "warn",
     }
 
@@ -77,6 +79,7 @@ def _start_docker(context, port, store, image):
 
 def before_all(context):
     port = _free_port()
+    context.port = port
     context.base_url = f"http://127.0.0.1:{port}"
 
     store = os.environ.get("STORE", "memory")

--- a/tests/integration/features/vhost.feature
+++ b/tests/integration/features/vhost.feature
@@ -1,0 +1,35 @@
+Feature: Virtual-host style addressing
+
+  Scenario: Put and get object via virtual-host
+    Given bucket "vhost-bucket" exists
+    When I put object "hello.txt" with body "hello world" via virtual-host to "vhost-bucket"
+    Then I can get object "hello.txt" via virtual-host from "vhost-bucket" with body "hello world"
+
+  Scenario: Create and head bucket via virtual-host
+    When I create bucket "vhost-create" via virtual-host
+    Then I can head bucket "vhost-create" via virtual-host
+
+  Scenario: List objects via virtual-host
+    Given bucket "vhost-list" exists
+    And object "vhost-list/a.txt" contains "aaa"
+    And object "vhost-list/b.txt" contains "bbb"
+    When I list objects via virtual-host from "vhost-list"
+    Then the virtual-host listing should contain "a.txt"
+    And the virtual-host listing should contain "b.txt"
+
+  Scenario: Delete object via virtual-host
+    Given bucket "vhost-del" exists
+    And object "vhost-del/doomed.txt" contains "bye"
+    When I vhost-delete object "doomed.txt" from "vhost-del"
+    Then getting object "doomed.txt" via virtual-host from "vhost-del" should fail
+
+  Scenario: Path-style still works alongside virtual-host
+    Given bucket "dual-bucket" exists
+    And object "dual-bucket/path-obj.txt" contains "via path"
+    When I get object "dual-bucket/path-obj.txt" via path-style
+    Then the path-style response body should be "via path"
+
+  Scenario: Cross-style access
+    Given bucket "cross-bucket" exists
+    When I put object "cross.txt" with body "cross data" via virtual-host to "cross-bucket"
+    Then object "cross-bucket/cross.txt" should contain "cross data"

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,2 +1,3 @@
 behave
 boto3
+requests

--- a/tests/integration/steps/vhost_steps.py
+++ b/tests/integration/steps/vhost_steps.py
@@ -1,0 +1,96 @@
+import requests
+from behave import when, then
+
+
+def _vhost_url(context, bucket, path=""):
+    return f"http://127.0.0.1:{context.port}/{path}"
+
+
+def _vhost_headers(context, bucket):
+    return {"Host": f"{bucket}.localhost:{context.port}"}
+
+
+@when('I put object "{key}" with body "{body}" via virtual-host to "{bucket}"')
+def step_vhost_put(context, key, body, bucket):
+    resp = requests.put(
+        _vhost_url(context, bucket, key),
+        data=body.encode(),
+        headers=_vhost_headers(context, bucket),
+    )
+    assert resp.status_code == 200, f"PUT failed: {resp.status_code} {resp.text}"
+
+
+@then('I can get object "{key}" via virtual-host from "{bucket}" with body "{expected}"')
+def step_vhost_get(context, key, bucket, expected):
+    resp = requests.get(
+        _vhost_url(context, bucket, key),
+        headers=_vhost_headers(context, bucket),
+    )
+    assert resp.status_code == 200, f"GET failed: {resp.status_code} {resp.text}"
+    assert resp.text == expected, f"expected {expected!r}, got {resp.text!r}"
+
+
+@when('I create bucket "{bucket}" via virtual-host')
+def step_vhost_create_bucket(context, bucket):
+    resp = requests.put(
+        f"http://127.0.0.1:{context.port}/",
+        headers=_vhost_headers(context, bucket),
+    )
+    assert resp.status_code == 200, f"PUT bucket failed: {resp.status_code} {resp.text}"
+
+
+@then('I can head bucket "{bucket}" via virtual-host')
+def step_vhost_head_bucket(context, bucket):
+    resp = requests.head(
+        f"http://127.0.0.1:{context.port}/",
+        headers=_vhost_headers(context, bucket),
+    )
+    assert resp.status_code == 200, f"HEAD bucket failed: {resp.status_code}"
+
+
+@when('I list objects via virtual-host from "{bucket}"')
+def step_vhost_list_objects(context, bucket):
+    resp = requests.get(
+        f"http://127.0.0.1:{context.port}/",
+        headers=_vhost_headers(context, bucket),
+    )
+    assert resp.status_code == 200, f"LIST failed: {resp.status_code} {resp.text}"
+    context.vhost_list_body = resp.text
+
+
+@then('the virtual-host listing should contain "{key}"')
+def step_vhost_list_contains(context, key):
+    assert f"<Key>{key}</Key>" in context.vhost_list_body, (
+        f"key {key} not found in listing: {context.vhost_list_body}"
+    )
+
+
+@when('I vhost-delete object "{key}" from "{bucket}"')
+def step_vhost_delete(context, key, bucket):
+    resp = requests.delete(
+        _vhost_url(context, bucket, key),
+        headers=_vhost_headers(context, bucket),
+    )
+    assert resp.status_code == 204, f"DELETE failed: {resp.status_code}"
+
+
+@then('getting object "{key}" via virtual-host from "{bucket}" should fail')
+def step_vhost_get_fails(context, key, bucket):
+    resp = requests.get(
+        _vhost_url(context, bucket, key),
+        headers=_vhost_headers(context, bucket),
+    )
+    assert resp.status_code == 404, f"expected 404, got {resp.status_code}"
+
+
+@when('I get object "{path}" via path-style')
+def step_path_style_get(context, path):
+    resp = requests.get(f"{context.base_url}/{path}")
+    context.path_style_response = resp
+
+
+@then('the path-style response body should be "{expected}"')
+def step_path_style_body(context, expected):
+    assert context.path_style_response.text == expected, (
+        f"expected {expected!r}, got {context.path_style_response.text!r}"
+    )


### PR DESCRIPTION
Requests to `bucket.localhost:4566/key` now route to the correct bucket/key by rewriting the URI before Axum's router sees it. Path-style addressing continues to work unchanged.

## Implementation & Notes
* A `VhostService` Tower Service wrapper sits outside Axum's Router, parsing the `Host` header for a bucket subdomain relative to a configurable base domain (`AWRUST_S3_BASE_DOMAIN`, default `localhost`), and prepends `/{bucket}` to the path before routing.
* Key insight: Axum's `Router::layer()` applies middleware _after_ route matching, so the rewrite must happen outside the Router via a raw Tower Service that wraps it. This ensures the rewritten URI is what the router matches against.
* New dependency: `tower 0.5` (for the `Service` trait implementation).

## How to Test
```bash
cargo test --workspace                    # 27 unit tests (9 vhost)
cd tests/integration && behave            # 28 BDD scenarios (6 vhost)
STORE=fs behave                           # filesystem backend

# Manual smoke test:
curl -X PUT http://localhost:4566/mybucket
curl -X PUT http://localhost:4566/mykey -H "Host: mybucket.localhost:4566" -d "hello"
curl http://localhost:4566/mykey -H "Host: mybucket.localhost:4566"
```

## Suggested Commit Message
```
S3-18 Add virtual-host style addressing (#XX)

Requests to bucket.localhost:4566/key now route to the correct
bucket and key by rewriting the URI before Axum's router sees it.
A Tower Service wrapper (VhostService) sits outside the Router,
parses the Host header for a bucket subdomain relative to a
configurable base domain (AWRUST_S3_BASE_DOMAIN, default
"localhost"), and prepends /{bucket} to the path. Path-style
addressing continues to work unchanged.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)