### PR TITLE
S3-35 Bind dual-stack so localhost works on Alpine

### DIFF
--- a/crates/awrust-s3-server/src/router.rs
+++ b/crates/awrust-s3-server/src/router.rs
@@ -66,7 +66,7 @@ pub(crate) fn build(store: Arc<dyn Store>) -> (VhostService<Router>, SocketAddr)
     let service = VhostService::new(app, base_domain);
 
     let addr: SocketAddr = std::env::var("AWRUST_S3_LISTEN_ADDR")
-        .unwrap_or_else(|_| "0.0.0.0:4566".to_string())
+        .unwrap_or_else(|_| "[::]:4566".to_string())
         .parse()
         .expect("valid listen addr");
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@ COPY --from=builder /build/target/release/awrust-s3-server /usr/local/bin/awrust
 
 USER awrust
 
-ENV AWRUST_S3_LISTEN_ADDR=0.0.0.0:4566
+ENV AWRUST_S3_LISTEN_ADDR=[::]:4566
 ENV AWRUST_S3_STORE=memory
 ENV AWRUST_S3_DATA_DIR=/data
 ENV AWRUST_LOG=info

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -6,7 +6,7 @@ All configuration is via environment variables.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `AWRUST_S3_LISTEN_ADDR` | `0.0.0.0:4566` | Listen address |
+| `AWRUST_S3_LISTEN_ADDR` | `[::]:4566` | Listen address (dual-stack IPv4+IPv6) |
 | `AWRUST_S3_STORE` | `memory` | Storage backend: `memory` or `fs` |
 | `AWRUST_S3_DATA_DIR` | `/data` | Data directory for `fs` backend |
 | `AWRUST_S3_BASE_DOMAIN` | `localhost` | Base domain for virtual-host addressing |

--- a/tests/integration/environment.py
+++ b/tests/integration/environment.py
@@ -56,7 +56,7 @@ def _start_cargo(context, port, store):
 
 def _start_docker(context, port, store, image):
     docker_env = {
-        "AWRUST_S3_LISTEN_ADDR": f"0.0.0.0:4566",
+        "AWRUST_S3_LISTEN_ADDR": f"[::]:4566",
         "AWRUST_S3_STORE": store,
         "AWRUST_S3_BASE_DOMAIN": "localhost",
         "AWRUST_LOG": "warn",


### PR DESCRIPTION
## Summary
- Default listen address changed from `0.0.0.0:4566` (IPv4-only) to `[::]:4566` (dual-stack IPv4+IPv6)
- On Alpine-based containers, `localhost` resolves to `::1` first — this caused `Connection refused` for health checks and SDK clients using `localhost`
- Aligns with MinIO and LocalStack, which bind dual-stack by default

## Test plan
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test --workspace` — 51 tests pass
- [ ] `IMAGE=awrust-s3:test behave` — verify Docker health check via `localhost` succeeds

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)