### PR TITLE
S3-34 Fix Last-Modified header to use RFC 7231 format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,7 @@ dependencies = [
  "awrust-s3-domain",
  "axum",
  "bytes",
+ "httpdate",
  "md-5",
  "quick-xml",
  "serde",

--- a/crates/awrust-s3-server/Cargo.toml
+++ b/crates/awrust-s3-server/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 awrust-s3-domain = { path = "../awrust-s3-domain" }
 axum = "0.7"
+httpdate = "1"
 bytes = "1"
 md-5 = "0.10"
 quick-xml = { version = "0.37", features = ["serialize", "serde"] }

--- a/crates/awrust-s3-server/src/handlers/format.rs
+++ b/crates/awrust-s3-server/src/handlers/format.rs
@@ -61,7 +61,7 @@ pub(crate) fn meta_to_headers(meta: &ObjectMeta) -> HeaderMap {
     );
     headers.insert(
         "last-modified",
-        format_iso8601(meta.last_modified)
+        format_httpdate(meta.last_modified)
             .parse()
             .expect("valid header"),
     );
@@ -77,14 +77,8 @@ pub(crate) fn meta_to_headers(meta: &ObjectMeta) -> HeaderMap {
 }
 
 pub(crate) fn format_iso8601(epoch_secs: u64) -> String {
-    let dt = UNIX_EPOCH + Duration::from_secs(epoch_secs);
-    let secs = dt
-        .duration_since(UNIX_EPOCH)
-        .expect("after epoch")
-        .as_secs();
-
-    let days = secs / 86400;
-    let time_secs = secs % 86400;
+    let days = epoch_secs / 86400;
+    let time_secs = epoch_secs % 86400;
     let hours = time_secs / 3600;
     let minutes = (time_secs % 3600) / 60;
     let seconds = time_secs % 60;
@@ -134,4 +128,53 @@ fn days_to_ymd(mut days: u64) -> (u64, u64, u64) {
 
 fn is_leap(year: u64) -> bool {
     (year.is_multiple_of(4) && !year.is_multiple_of(100)) || year.is_multiple_of(400)
+}
+
+pub(crate) fn format_httpdate(epoch_secs: u64) -> String {
+    httpdate::fmt_http_date(UNIX_EPOCH + Duration::from_secs(epoch_secs))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn httpdate_formats_rfc7231() {
+        assert_eq!(
+            format_httpdate(1_775_602_214),
+            "Tue, 07 Apr 2026 22:50:14 GMT"
+        );
+    }
+
+    #[test]
+    fn httpdate_epoch_zero() {
+        assert_eq!(format_httpdate(0), "Thu, 01 Jan 1970 00:00:00 GMT");
+    }
+
+    #[test]
+    fn httpdate_leap_day() {
+        assert_eq!(
+            format_httpdate(1_709_208_000),
+            "Thu, 29 Feb 2024 12:00:00 GMT"
+        );
+    }
+
+    #[test]
+    fn iso8601_known_timestamp() {
+        assert_eq!(format_iso8601(1_775_602_214), "2026-04-07T22:50:14.000Z");
+    }
+
+    #[test]
+    fn meta_headers_use_rfc7231_for_last_modified() {
+        let meta = ObjectMeta {
+            etag: "\"abc\"".to_string(),
+            size: 5,
+            content_type: "text/plain".to_string(),
+            last_modified: 1_775_602_214,
+            metadata: Default::default(),
+        };
+        let headers = meta_to_headers(&meta);
+        let last_mod = headers.get("last-modified").unwrap().to_str().unwrap();
+        assert_eq!(last_mod, "Tue, 07 Apr 2026 22:50:14 GMT");
+    }
 }

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -132,7 +132,7 @@ All responses include permissive CORS headers. `OPTIONS` preflight requests are 
 | `ETag` | MD5 for single-part, composite `MD5-N` for multipart |
 | `Content-Type` | Original MIME type |
 | `Content-Length` | Body size in bytes |
-| `Last-Modified` | ISO 8601 timestamp |
+| `Last-Modified` | RFC 7231 (IMF-fixdate) timestamp |
 | `x-amz-meta-*` | Custom metadata |
 | `x-amz-request-id` | UUID per request |
 | `Accept-Ranges` | `bytes` (on GET/HEAD object) |

--- a/docs/adr/ADR-0008.md
+++ b/docs/adr/ADR-0008.md
@@ -1,0 +1,28 @@
+# ADR-0008: Use httpdate crate for RFC 7231 timestamp formatting
+
+## Status
+Accepted
+
+## Context
+S3's `Last-Modified` HTTP header must use the RFC 7231 IMF-fixdate format (`Tue, 07 Apr 2026 22:50:14 GMT`). We were emitting ISO 8601 instead, breaking the AWS SDK for Java v2 response parser.
+
+We need a reliable formatter for this well-specified format. The `httpdate` crate is a single-purpose, zero-dependency, widely-used implementation that is already present in our dependency tree as a transitive dependency of `hyper`.
+
+## Decision
+Add `httpdate = "1"` as a direct dependency of `awrust-s3-server` and use `httpdate::fmt_http_date` for HTTP response headers.
+
+ISO 8601 formatting (used in XML response bodies) remains hand-rolled since it is trivial and not covered by `httpdate`.
+
+## Alternatives considered
+- **Hand-rolled formatter**: More code to maintain, higher risk of subtle calendar bugs (day-of-week, leap years). No upside given the crate already exists in the tree.
+- **chrono**: Full-featured datetime library. Massive dependency surface for a single format string.
+- **time**: Similar to chrono — far more than we need.
+
+## Consequences
+Positive:
+- Zero added compile-time cost (already in the dependency graph)
+- Battle-tested implementation trusted by the Rust HTTP ecosystem
+- One-liner replaces ~15 lines of hand-rolled calendar math
+
+Negative:
+- Direct dependency on an external crate (mitigated: zero transitive deps, stable API, already transitively depended upon)

--- a/tests/integration/features/object.feature
+++ b/tests/integration/features/object.feature
@@ -37,3 +37,7 @@ Feature: Object operations
     When I upload "obj-bucket/meta.txt" with body "data" and metadata "color=blue,env=test"
     Then object "obj-bucket/meta.txt" should have metadata "color" with value "blue"
     And object "obj-bucket/meta.txt" should have metadata "env" with value "test"
+
+  Scenario: Last-Modified header uses RFC 7231 format
+    When I put object "obj-bucket/rfc-test.txt" with content "ts"
+    Then the last modified header for "obj-bucket/rfc-test.txt" should be RFC 7231 format

--- a/tests/integration/steps/object_steps.py
+++ b/tests/integration/steps/object_steps.py
@@ -1,3 +1,5 @@
+import re
+
 from behave import given, when, then
 from botocore.exceptions import ClientError
 
@@ -121,4 +123,21 @@ def step_assert_metadata(context, path, meta_key, meta_value):
     actual = metadata.get(meta_key)
     assert actual == meta_value, (
         f"expected metadata {meta_key}={meta_value}, got {actual} (all: {metadata})"
+    )
+
+
+RFC_7231_PATTERN = re.compile(
+    r"^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{2} "
+    r"(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) "
+    r"\d{4} \d{2}:\d{2}:\d{2} GMT$"
+)
+
+
+@then('the last modified header for "{path}" should be RFC 7231 format')
+def step_assert_last_modified_rfc7231(context, path):
+    bucket, key = _split(path)
+    resp = context.s3.head_object(Bucket=bucket, Key=key)
+    last_mod = resp["ResponseMetadata"]["HTTPHeaders"]["last-modified"]
+    assert RFC_7231_PATTERN.match(last_mod), (
+        f"expected RFC 7231 format, got {last_mod!r}"
     )


### PR DESCRIPTION
Fix `Last-Modified` HTTP header to emit RFC 7231 IMF-fixdate format instead of ISO 8601, unblocking AWS SDK for Java v2 response parsing.

## Implementation & Notes
* Use the `httpdate` crate (already transitively depended upon via `hyper`) for HTTP response headers — one-liner replaces hand-rolled calendar math.
* XML response bodies (`ListBucketResult`, `CopyObjectResult`, etc.) correctly retain ISO 8601.
* Cleaned up a redundant `UNIX_EPOCH` round-trip in `format_iso8601`.
* ADR-0008 documents the new direct dependency.

## How to Test
```bash
cargo test --workspace
cd tests/integration && behave features/object.feature
```

The new BDD scenario "Last-Modified header uses RFC 7231 format" validates the fix end-to-end via boto3.

## Breaking Changes
Yes — the `Last-Modified` HTTP header format changes from `2026-04-07T22:50:14.000Z` to `Tue, 07 Apr 2026 22:50:14 GMT`. This is a fix toward spec compliance; any client relying on the old ISO 8601 format was depending on incorrect behavior.

## Suggested Commit Message
```
S3-34 Fix Last-Modified header to use RFC 7231 format (#XX)

The Last-Modified HTTP header was emitting ISO 8601 instead of
the RFC 7231 IMF-fixdate format required by the S3 spec. This
broke AWS SDK for Java v2 response parsing. Use the httpdate
crate (transitive dep via hyper) for HTTP headers; XML bodies
retain ISO 8601.

Closes #34

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)