### PR TITLE
S3-38 Decode aws-chunked content encoding on PutObject

### DIFF
--- a/crates/awrust-s3-domain/src/chunked.rs
+++ b/crates/awrust-s3-domain/src/chunked.rs
@@ -1,0 +1,144 @@
+use crate::StoreError;
+
+pub fn decode_aws_chunked(input: &[u8]) -> Result<Vec<u8>, StoreError> {
+    let err = || StoreError::InvalidChunkedEncoding;
+    let mut pos = 0;
+    let mut output = Vec::new();
+
+    loop {
+        let line_end = memchr_crlf(input, pos).ok_or_else(err)?;
+        let line = &input[pos..line_end];
+
+        let hex_part = match line.iter().position(|&b| b == b';') {
+            Some(i) => &line[..i],
+            None => line,
+        };
+
+        let size = usize::from_str_radix(std::str::from_utf8(hex_part).map_err(|_| err())?, 16)
+            .map_err(|_| err())?;
+
+        pos = line_end + 2;
+
+        if size == 0 {
+            break;
+        }
+
+        let chunk_end = pos.checked_add(size).ok_or_else(err)?;
+        if input.len() < chunk_end + 2 {
+            return Err(err());
+        }
+
+        output.extend_from_slice(&input[pos..chunk_end]);
+        pos = chunk_end + 2;
+    }
+
+    Ok(output)
+}
+
+fn memchr_crlf(haystack: &[u8], start: usize) -> Option<usize> {
+    let mut i = start;
+    while i + 1 < haystack.len() {
+        if haystack[i] == b'\r' && haystack[i + 1] == b'\n' {
+            return Some(i);
+        }
+        i += 1;
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn chunked_frame(chunks: &[&[u8]]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        for chunk in chunks {
+            buf.extend_from_slice(format!("{:x}\r\n", chunk.len()).as_bytes());
+            buf.extend_from_slice(chunk);
+            buf.extend_from_slice(b"\r\n");
+        }
+        buf.extend_from_slice(b"0\r\n\r\n");
+        buf
+    }
+
+    fn chunked_frame_with_signatures(chunks: &[&[u8]]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        for chunk in chunks {
+            buf.extend_from_slice(format!("{:x};chunk-signature=aaaa\r\n", chunk.len()).as_bytes());
+            buf.extend_from_slice(chunk);
+            buf.extend_from_slice(b"\r\n");
+        }
+        buf.extend_from_slice(b"0;chunk-signature=aaaa\r\n\r\n");
+        buf
+    }
+
+    #[test]
+    fn single_chunk() {
+        let input = chunked_frame(&[b"hello world"]);
+        let decoded = decode_aws_chunked(&input).unwrap();
+        assert_eq!(decoded, b"hello world");
+    }
+
+    #[test]
+    fn multiple_chunks() {
+        let input = chunked_frame(&[b"hello ", b"world"]);
+        let decoded = decode_aws_chunked(&input).unwrap();
+        assert_eq!(decoded, b"hello world");
+    }
+
+    #[test]
+    fn with_chunk_signature_extensions() {
+        let input = chunked_frame_with_signatures(&[b"payload"]);
+        let decoded = decode_aws_chunked(&input).unwrap();
+        assert_eq!(decoded, b"payload");
+    }
+
+    #[test]
+    fn empty_body() {
+        let input = b"0\r\n\r\n";
+        let decoded = decode_aws_chunked(input).unwrap();
+        assert!(decoded.is_empty());
+    }
+
+    #[test]
+    fn binary_data() {
+        let binary: Vec<u8> = (0..=255).collect();
+        let input = chunked_frame(&[&binary]);
+        let decoded = decode_aws_chunked(&input).unwrap();
+        assert_eq!(decoded, binary);
+    }
+
+    #[test]
+    fn large_multi_chunk() {
+        let a = vec![0xAA; 16384];
+        let b = vec![0xBB; 8192];
+        let input = chunked_frame(&[&a, &b]);
+        let decoded = decode_aws_chunked(&input).unwrap();
+        let mut expected = a;
+        expected.extend_from_slice(&b);
+        assert_eq!(decoded, expected);
+    }
+
+    #[test]
+    fn trailing_headers_ignored() {
+        let mut input = Vec::new();
+        input.extend_from_slice(b"5\r\nhello\r\n");
+        input.extend_from_slice(b"0\r\n");
+        input.extend_from_slice(b"x-amz-checksum:abc\r\n");
+        input.extend_from_slice(b"\r\n");
+        let decoded = decode_aws_chunked(&input).unwrap();
+        assert_eq!(decoded, b"hello");
+    }
+
+    #[test]
+    fn invalid_hex_returns_error() {
+        let input = b"ZZZZ\r\ndata\r\n0\r\n\r\n";
+        assert!(decode_aws_chunked(input).is_err());
+    }
+
+    #[test]
+    fn truncated_input_returns_error() {
+        let input = b"5\r\nhi";
+        assert!(decode_aws_chunked(input).is_err());
+    }
+}

--- a/crates/awrust-s3-domain/src/error.rs
+++ b/crates/awrust-s3-domain/src/error.rs
@@ -9,6 +9,7 @@ pub enum StoreError {
     ObjectNotFound { bucket: String, key: String },
     UploadNotFound(String),
     InvalidPart { upload_id: String, part_number: u32 },
+    InvalidChunkedEncoding,
 }
 
 impl fmt::Display for StoreError {
@@ -24,6 +25,7 @@ impl fmt::Display for StoreError {
                 upload_id,
                 part_number,
             } => write!(f, "invalid part {part_number} for upload {upload_id}"),
+            StoreError::InvalidChunkedEncoding => write!(f, "invalid aws-chunked encoding"),
         }
     }
 }

--- a/crates/awrust-s3-domain/src/lib.rs
+++ b/crates/awrust-s3-domain/src/lib.rs
@@ -1,3 +1,4 @@
+mod chunked;
 mod error;
 mod fs_store;
 mod memory_store;
@@ -5,6 +6,7 @@ mod store;
 mod types;
 mod util;
 
+pub use chunked::decode_aws_chunked;
 pub use error::{Result, StoreError};
 pub use fs_store::FsStore;
 pub use memory_store::MemoryStore;

--- a/crates/awrust-s3-server/src/error.rs
+++ b/crates/awrust-s3-server/src/error.rs
@@ -41,6 +41,11 @@ impl IntoResponse for S3Error {
                 "InvalidPart",
                 format!("Invalid part {part_number} for upload {upload_id}"),
             ),
+            StoreError::InvalidChunkedEncoding => (
+                StatusCode::BAD_REQUEST,
+                "InvalidArgument",
+                "Could not decode aws-chunked request body".to_string(),
+            ),
         };
 
         let body = format!(

--- a/crates/awrust-s3-server/src/handlers/object.rs
+++ b/crates/awrust-s3-server/src/handlers/object.rs
@@ -1,4 +1,4 @@
-use awrust_s3_domain::{PutObject, Store};
+use awrust_s3_domain::{PutObject, Store, decode_aws_chunked};
 use axum::body::Bytes;
 use axum::extract::{Path, Query, State};
 use axum::http::{HeaderMap, StatusCode};
@@ -39,7 +39,18 @@ pub async fn put_object_or_part(
     }
 
     if let (Some(upload_id), Some(part_number)) = (&params.upload_id, params.part_number) {
-        let etag = store.upload_part(&bucket, &key, upload_id, part_number, body.to_vec())?;
+        let is_aws_chunked = headers
+            .get("content-encoding")
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(|v| v.contains("aws-chunked"));
+
+        let part_bytes = if is_aws_chunked {
+            decode_aws_chunked(&body)?
+        } else {
+            body.to_vec()
+        };
+
+        let etag = store.upload_part(&bucket, &key, upload_id, part_number, part_bytes)?;
         return Ok((StatusCode::OK, [("etag", etag)]).into_response());
     }
 
@@ -51,11 +62,22 @@ pub async fn put_object_or_part(
 
     let metadata = extract_amz_meta(&headers);
 
+    let is_aws_chunked = headers
+        .get("content-encoding")
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| v.contains("aws-chunked"));
+
+    let bytes = if is_aws_chunked {
+        decode_aws_chunked(&body)?
+    } else {
+        body.to_vec()
+    };
+
     store.put_object(
         &bucket,
         &key,
         PutObject {
-            bytes: body.to_vec(),
+            bytes,
             content_type,
             metadata,
         },

--- a/tests/integration/features/aws_chunked.feature
+++ b/tests/integration/features/aws_chunked.feature
@@ -1,0 +1,12 @@
+Feature: aws-chunked content encoding
+
+  Background:
+    Given bucket "chunked-bucket" exists
+
+  Scenario: PutObject with aws-chunked encoding stores decoded content
+    When I put an aws-chunked object "chunked-bucket/test.json" with content '{"status":"ok"}'
+    Then the aws-chunked object "chunked-bucket/test.json" should contain '{"status":"ok"}'
+
+  Scenario: Large aws-chunked upload with multiple chunks
+    When I put a large aws-chunked object "chunked-bucket/big.bin" of 32768 bytes
+    Then object "chunked-bucket/big.bin" should have content length 32768

--- a/tests/integration/steps/aws_chunked_steps.py
+++ b/tests/integration/steps/aws_chunked_steps.py
@@ -1,0 +1,64 @@
+import urllib.request
+
+from behave import when, then
+
+
+def _encode_aws_chunked(data: bytes) -> bytes:
+    chunk_size = 16384
+    buf = bytearray()
+    offset = 0
+    while offset < len(data):
+        end = min(offset + chunk_size, len(data))
+        chunk = data[offset:end]
+        buf.extend(f"{len(chunk):x}\r\n".encode())
+        buf.extend(chunk)
+        buf.extend(b"\r\n")
+        offset = end
+    buf.extend(b"0\r\n\r\n")
+    return bytes(buf)
+
+
+@when("I put an aws-chunked object \"{path}\" with content '{content}'")
+def step_put_aws_chunked(context, path, content):
+    bucket, key = path.split("/", 1)
+    raw = content.encode()
+    chunked_body = _encode_aws_chunked(raw)
+
+    url = f"{context.base_url}/{bucket}/{key}"
+    req = urllib.request.Request(url, data=chunked_body, method="PUT")
+    req.add_header("content-encoding", "aws-chunked")
+    req.add_header("x-amz-content-sha256", "STREAMING-AWS4-HMAC-SHA256-PAYLOAD")
+    req.add_header("x-amz-decoded-content-length", str(len(raw)))
+    urllib.request.urlopen(req)
+
+
+@when(
+    'I put a large aws-chunked object "{path}" of {size:d} bytes'
+)
+def step_put_large_aws_chunked(context, path, size):
+    bucket, key = path.split("/", 1)
+    raw = bytes(range(256)) * (size // 256) + bytes(range(size % 256))
+    chunked_body = _encode_aws_chunked(raw)
+
+    url = f"{context.base_url}/{bucket}/{key}"
+    req = urllib.request.Request(url, data=chunked_body, method="PUT")
+    req.add_header("content-encoding", "aws-chunked")
+    req.add_header("x-amz-content-sha256", "STREAMING-AWS4-HMAC-SHA256-PAYLOAD")
+    req.add_header("x-amz-decoded-content-length", str(len(raw)))
+    urllib.request.urlopen(req)
+
+
+@then("the aws-chunked object \"{path}\" should contain '{content}'")
+def step_assert_aws_chunked_content(context, path, content):
+    bucket, key = path.split("/", 1)
+    resp = context.s3.get_object(Bucket=bucket, Key=key)
+    body = resp["Body"].read().decode()
+    assert body == content, f"expected {content!r}, got {body!r}"
+
+
+@then('object "{path}" should have content length {expected:d}')
+def step_assert_content_length(context, path, expected):
+    bucket, key = path.split("/", 1)
+    resp = context.s3.get_object(Bucket=bucket, Key=key)
+    body = resp["Body"].read()
+    assert len(body) == expected, f"expected {expected} bytes, got {len(body)}"


### PR DESCRIPTION
Decode aws-chunked content encoding before storing objects, fixing corrupted uploads from AWS SDK v2 async clients.

Closes #38

## Implementation & Notes
* Added `decode_aws_chunked()` in the domain crate — a pure function that parses hex chunk sizes (with optional `;chunk-signature=...` extensions), extracts data bytes, and handles trailing headers.
* The PutObject handler now detects `content-encoding: aws-chunked` and decodes the body before storing — for both single puts and multipart upload parts.
* Added `InvalidChunkedEncoding` error variant mapped to HTTP 400 `InvalidArgument`.

## How to Test
```bash
cargo test --workspace
cd tests/integration && behave features/aws_chunked.feature
STORE=fs behave features/aws_chunked.feature
```

## Suggested Commit Message
```
S3-38 Decode aws-chunked content encoding on PutObject (#XX)

The AWS SDK v2 uses content-encoding: aws-chunked for streaming
uploads where content length is unknown upfront. The server was
storing the raw chunked body instead of decoding it first.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)