### PR TITLE
AW-20 Make DeleteObject idempotent per S3 spec

### DIFF
--- a/crates/awrust-s3-domain/src/fs_store.rs
+++ b/crates/awrust-s3-domain/src/fs_store.rs
@@ -225,15 +225,7 @@ impl Store for FsStore {
     fn delete_object(&self, bucket: &str, key: &str) -> Result<()> {
         self.require_bucket(bucket)?;
 
-        let obj_path = self.object_path(bucket, key);
-        if !obj_path.exists() {
-            return Err(StoreError::ObjectNotFound {
-                bucket: bucket.to_string(),
-                key: key.to_string(),
-            });
-        }
-
-        fs::remove_file(obj_path).ok();
+        fs::remove_file(self.object_path(bucket, key)).ok();
         fs::remove_file(self.meta_path(bucket, key)).ok();
         Ok(())
     }

--- a/crates/awrust-s3-domain/src/memory_store.rs
+++ b/crates/awrust-s3-domain/src/memory_store.rs
@@ -173,13 +173,7 @@ impl Store for MemoryStore {
             .get_mut(bucket)
             .ok_or_else(|| StoreError::BucketNotFound(bucket.to_string()))?;
 
-        if bucket_state.objects.remove(key).is_none() {
-            return Err(StoreError::ObjectNotFound {
-                bucket: bucket.to_string(),
-                key: key.to_string(),
-            });
-        }
-
+        bucket_state.objects.remove(key);
         Ok(())
     }
 
@@ -412,6 +406,13 @@ impl Store for MemoryStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn delete_nonexistent_object_succeeds() {
+        let store = MemoryStore::new();
+        store.create_bucket("b").unwrap();
+        assert!(store.delete_object("b", "ghost.txt").is_ok());
+    }
 
     #[test]
     fn list_multipart_uploads_empty() {

--- a/crates/awrust-s3-server/src/handlers/bucket.rs
+++ b/crates/awrust-s3-server/src/handlers/bucket.rs
@@ -63,7 +63,7 @@ pub async fn post_bucket(
 
     for obj in &request.objects {
         match store.delete_object(&bucket, &obj.key) {
-            Ok(()) | Err(awrust_s3_domain::StoreError::ObjectNotFound { .. }) => {
+            Ok(()) => {
                 if !request.quiet {
                     deleted.push(DeletedEntry {
                         key: obj.key.clone(),

--- a/tests/integration/features/object.feature
+++ b/tests/integration/features/object.feature
@@ -19,6 +19,10 @@ Feature: Object operations
     When I list objects in "obj-bucket" with prefix "a/"
     Then the listed keys should be "a/1.txt,a/2.txt"
 
+  Scenario: Delete a non-existent object succeeds
+    When I delete object "obj-bucket/ghost.txt"
+    Then object "obj-bucket/ghost.txt" should not exist
+
   Scenario: Get non-existent object fails
     When I try to get object "obj-bucket/nope.txt"
     Then the operation should fail


### PR DESCRIPTION
Make `DeleteObject` return 204 No Content for non-existent keys, matching the S3 spec and real AWS/LocalStack behavior.

## Implementation & Notes
* Both `MemoryStore` and `FsStore` `delete_object` methods returned `ObjectNotFound` when the key didn't exist — removed the existence check so they always return `Ok(())`.
* The batch delete handler (`post_bucket`) had a workaround matching `Ok(()) | Err(ObjectNotFound)` — simplified to just `Ok(())` since the error can no longer surface from `delete_object`.
* Added unit test (`delete_nonexistent_object_succeeds`) and BDD scenario ("Delete a non-existent object succeeds").

## How to Test
```bash
cargo test --workspace
STORE=memory behave
STORE=fs behave
```

Manual smoke test:
```bash
docker run -d --name awrust-s3 -p 4566:4566 <image>
aws --endpoint-url http://localhost:4566 s3 mb s3://test-bucket
aws --endpoint-url http://localhost:4566 s3api delete-object \
  --bucket test-bucket --key nonexistent.html
# Should succeed silently (204), not return NoSuchKey
```

## Breaking Changes
Services that relied on `NoSuchKey` errors from `DeleteObject` to detect missing keys will no longer receive that signal. This is intentional — the previous behavior was non-compliant with the S3 spec. Any such detection should use `HeadObject` instead.

## Suggested Commit Message
```
AW-20 Make DeleteObject idempotent per S3 spec (#XX)

S3 DeleteObject must return 204 even when the key does not exist.
Both MemoryStore and FsStore incorrectly returned ObjectNotFound,
which broke services that call deleteObject defensively.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
```